### PR TITLE
Module 3: seamless checkout and redemption

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ All specs live in `/docs`. Read these before writing code for a module.
 - All API routes go through `routers/`. Services contain business logic only, no HTTP concerns.
 - Use `async def` for all route handlers and service functions that do I/O.
 - JSON arrays/objects stored in SQLite as TEXT. Serialize with `json.dumps()`, deserialize with `json.loads()`.
+- All timestamps are UTC. Use `datetime.now(timezone.utc)` for new timestamps and treat naive strings from SQLite (`CURRENT_TIMESTAMP`) as UTC. Never use `datetime.now()` (local-time, naive) for stored or compared values.
 - Cache external API responses (weather: 10 min). Never block offer generation on a failed external call.
 - When installing new packages: `pip install <package>`, then `pip freeze > requirements.txt`.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import init_db
-from routers import merchants
+from routers import merchants, offers, redemption
 
 
 @asynccontextmanager
@@ -24,6 +24,8 @@ app.add_middleware(
 )
 
 app.include_router(merchants.router)
+app.include_router(offers.router)
+app.include_router(redemption.router)
 
 
 @app.get("/api/health")

--- a/backend/routers/merchants.py
+++ b/backend/routers/merchants.py
@@ -1,7 +1,10 @@
 import json
-from fastapi import APIRouter
+from collections import Counter
+
+from fastapi import APIRouter, HTTPException
+
 from database import get_db
-from models import Merchant, MerchantRule, MerchantListResponse
+from models import Merchant, MerchantRule, MerchantListResponse, OfferAnalytics
 
 router = APIRouter(prefix="/api/merchants", tags=["merchants"])
 
@@ -54,5 +57,74 @@ async def list_merchants():
             )
 
         return MerchantListResponse(merchants=merchants)
+    finally:
+        await db.close()
+
+
+@router.get("/{merchant_id}/analytics", response_model=OfferAnalytics)
+async def merchant_analytics(merchant_id: str):
+    db = await get_db()
+    try:
+        check = await db.execute("SELECT 1 FROM merchants WHERE id = ?", (merchant_id,))
+        if await check.fetchone() is None:
+            raise HTTPException(status_code=404, detail="Merchant not found")
+
+        counts_cursor = await db.execute(
+            """SELECT
+                 COUNT(*) AS total_generated,
+                 SUM(CASE WHEN status = 'accepted' THEN 1 ELSE 0 END) AS total_accepted,
+                 SUM(CASE WHEN status = 'declined' THEN 1 ELSE 0 END) AS total_declined,
+                 SUM(CASE WHEN status = 'expired'  THEN 1 ELSE 0 END) AS total_expired,
+                 SUM(CASE WHEN status = 'redeemed' THEN 1 ELSE 0 END) AS total_redeemed
+               FROM offers WHERE merchant_id = ?""",
+            (merchant_id,),
+        )
+        counts = await counts_cursor.fetchone()
+
+        revenue_cursor = await db.execute(
+            """SELECT COALESCE(SUM(r.cashback_amount), 0.0) AS revenue
+               FROM redemptions r
+               JOIN offers o ON o.id = r.offer_id
+               WHERE o.merchant_id = ?""",
+            (merchant_id,),
+        )
+        revenue_row = await revenue_cursor.fetchone()
+        revenue_impact = float(revenue_row["revenue"] if revenue_row else 0.0)
+
+        tags_cursor = await db.execute(
+            "SELECT context_tags FROM offers WHERE merchant_id = ?",
+            (merchant_id,),
+        )
+        tag_rows = await tags_cursor.fetchall()
+        counter: Counter = Counter()
+        for r in tag_rows:
+            try:
+                counter.update(json.loads(r["context_tags"] or "[]"))
+            except (TypeError, ValueError):
+                continue
+        top_triggers = [tag for tag, _ in counter.most_common(5)]
+
+        total_generated = int(counts["total_generated"] or 0) if counts else 0
+        total_accepted = int(counts["total_accepted"] or 0) if counts else 0
+        total_declined = int(counts["total_declined"] or 0) if counts else 0
+        total_expired = int(counts["total_expired"] or 0) if counts else 0
+        total_redeemed = int(counts["total_redeemed"] or 0) if counts else 0
+
+        ever_accepted = total_accepted + total_redeemed
+        acceptance_rate = ever_accepted / max(ever_accepted + total_declined, 1)
+        redemption_rate = total_redeemed / max(ever_accepted, 1)
+
+        return OfferAnalytics(
+            merchant_id=merchant_id,
+            total_generated=total_generated,
+            total_accepted=total_accepted,
+            total_declined=total_declined,
+            total_expired=total_expired,
+            total_redeemed=total_redeemed,
+            acceptance_rate=round(acceptance_rate, 3),
+            redemption_rate=round(redemption_rate, 3),
+            top_context_triggers=top_triggers,
+            revenue_impact_estimate=round(revenue_impact, 2),
+        )
     finally:
         await db.close()

--- a/backend/routers/offers.py
+++ b/backend/routers/offers.py
@@ -1,0 +1,88 @@
+"""Offers router (stub).
+
+This stub provides the minimum surface needed for the redemption flow:
+list offers for a session and update offer state (accept/decline/dismiss).
+The offer-engine teammate will extend it with /generate and richer logic.
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+
+from database import get_db
+from models import OfferActionRequest
+from services import redemption as svc
+
+
+router = APIRouter(prefix="/api/offers", tags=["offers"])
+
+
+VALID_ACTIONS = {"accept", "decline", "dismiss"}
+
+
+@router.get("")
+async def list_offers(session_id: str, status: Optional[str] = None):
+    db = await get_db()
+    try:
+        if status:
+            cursor = await db.execute(
+                """SELECT * FROM offers
+                   WHERE user_session_id = ? AND status = ?
+                   ORDER BY created_at DESC""",
+                (session_id, status),
+            )
+        else:
+            cursor = await db.execute(
+                """SELECT * FROM offers
+                   WHERE user_session_id = ?
+                   ORDER BY created_at DESC""",
+                (session_id,),
+            )
+        rows = await cursor.fetchall()
+        offers = [svc._row_to_offer(r) for r in rows]
+        return {"offers": offers}
+    finally:
+        await db.close()
+
+
+@router.patch("/{offer_id}")
+async def update_offer(offer_id: str, req: OfferActionRequest):
+    if req.action not in VALID_ACTIONS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"action must be one of {sorted(VALID_ACTIONS)}",
+        )
+
+    db = await get_db()
+    try:
+        cursor = await db.execute("SELECT * FROM offers WHERE id = ?", (offer_id,))
+        row = await cursor.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Offer not found")
+
+        current_status = row["status"]
+        if current_status != "active":
+            raise HTTPException(
+                status_code=400,
+                detail=f"Offer no longer actionable (status: {current_status})",
+            )
+
+        if req.action == "accept":
+            token = svc.generate_token()
+            await db.execute(
+                "UPDATE offers SET status = 'accepted', redemption_token = ? WHERE id = ?",
+                (token, offer_id),
+            )
+        else:
+            await db.execute(
+                "UPDATE offers SET status = 'declined' WHERE id = ?", (offer_id,)
+            )
+        await db.commit()
+
+        cursor = await db.execute("SELECT * FROM offers WHERE id = ?", (offer_id,))
+        latest = await cursor.fetchone()
+        if latest is None:
+            raise HTTPException(status_code=500, detail="Offer disappeared after update")
+        return {"offer": svc._row_to_offer(latest)}
+    finally:
+        await db.close()

--- a/backend/routers/redemption.py
+++ b/backend/routers/redemption.py
@@ -1,0 +1,96 @@
+"""Redemption endpoints: QR fetch, validate, redeem, wallet."""
+
+from fastapi import APIRouter, HTTPException
+
+from database import get_db
+from models import (
+    Offer,
+    RedemptionRequest,
+    RedemptionResult,
+    TokenValidationResponse,
+)
+from services import redemption as svc
+
+
+router = APIRouter(prefix="/api", tags=["redemption"])
+
+
+@router.get("/redeem/qr/{offer_id}")
+async def get_offer_qr(offer_id: str):
+    db = await get_db()
+    try:
+        cursor = await db.execute("SELECT * FROM offers WHERE id = ?", (offer_id,))
+        row = await cursor.fetchone()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Offer not found")
+        offer = svc._row_to_offer(row)
+        if offer.status.value != "accepted" or not offer.redemption_token:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Offer not in accepted state (status: {offer.status.value})",
+            )
+        qr_b64 = svc.generate_qr_png_base64(offer.redemption_token)
+        return {
+            "qr_base64": qr_b64,
+            "token": offer.redemption_token,
+            "expires_at": offer.expires_at.isoformat(),
+        }
+    finally:
+        await db.close()
+
+
+@router.get("/redeem/validate/{token}", response_model=TokenValidationResponse)
+async def validate(token: str):
+    db = await get_db()
+    try:
+        is_valid, offer, _reason = await svc.validate_redemption(db, token)
+        if not is_valid or offer is None:
+            return TokenValidationResponse(valid=False, offer=None, merchant_name=None)
+        return TokenValidationResponse(
+            valid=True, offer=offer, merchant_name=offer.merchant_name
+        )
+    finally:
+        await db.close()
+
+
+@router.post("/redeem", response_model=RedemptionResult)
+async def redeem(req: RedemptionRequest):
+    db = await get_db()
+    try:
+        is_valid, offer, reason = await svc.validate_redemption(
+            db, req.token, offer_id=req.offer_id
+        )
+        if not is_valid or offer is None:
+            return RedemptionResult(
+                success=False, offer=offer, message=reason, cashback_amount=None
+            )
+
+        cashback, _redemption_id = await svc.commit_redemption(db, offer)
+
+        cursor = await db.execute("SELECT * FROM offers WHERE id = ?", (offer.id,))
+        latest_row = await cursor.fetchone()
+        latest_offer: Offer = svc._row_to_offer(latest_row) if latest_row else offer
+
+        message = (
+            f"Redeemed at {latest_offer.merchant_name}. ${cashback:.2f} cashback applied."
+        )
+        return RedemptionResult(
+            success=True, offer=latest_offer, message=message, cashback_amount=cashback
+        )
+    finally:
+        await db.close()
+
+
+@router.get("/wallet/{session_id}")
+async def get_wallet(session_id: str):
+    db = await get_db()
+    try:
+        balance = await svc.get_wallet_balance(db, session_id)
+        redemptions = await svc.list_session_redemptions(db, session_id)
+        return {
+            "balance_usd": balance,
+            "redemption_count": len(redemptions),
+            "redemptions": redemptions,
+        }
+    finally:
+        await db.close()

--- a/backend/routers/redemption.py
+++ b/backend/routers/redemption.py
@@ -65,7 +65,14 @@ async def redeem(req: RedemptionRequest):
                 success=False, offer=offer, message=reason, cashback_amount=None
             )
 
-        cashback, _redemption_id = await svc.commit_redemption(db, offer)
+        committed, cashback, _redemption_id = await svc.commit_redemption(db, offer)
+        if not committed:
+            return RedemptionResult(
+                success=False,
+                offer=offer,
+                message="Offer already redeemed",
+                cashback_amount=None,
+            )
 
         cursor = await db.execute("SELECT * FROM offers WHERE id = ?", (offer.id,))
         latest_row = await cursor.fetchone()

--- a/backend/seed_test_offers.py
+++ b/backend/seed_test_offers.py
@@ -14,7 +14,7 @@ import json
 import random
 import sys
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from database import get_db, init_db
 from services.redemption import generate_token
@@ -56,7 +56,9 @@ async def seed_test_offers(session_id: str, count: int = 3):
                 "headline_style": "emotional",
             }
             tags = random.sample(SAMPLE_TAGS, 3)
-            expires_at = (datetime.now() + timedelta(minutes=30)).isoformat()
+            expires_at = (
+                datetime.now(timezone.utc) + timedelta(minutes=30)
+            ).isoformat()
 
             await db.execute(
                 """INSERT INTO offers (

--- a/backend/seed_test_offers.py
+++ b/backend/seed_test_offers.py
@@ -1,0 +1,102 @@
+"""Seed accepted offers with redemption tokens for end-to-end testing.
+
+Usage (run from backend/):
+    python seed_test_offers.py <session_id> [count]
+
+Creates `count` offers (default 3), one per merchant, all in 'accepted' state
+with a fresh UUID redemption token and a 30-minute expiry. Prints each
+offer/token pair so you can paste into the merchant scanner without bouncing
+through the wallet page.
+"""
+
+import asyncio
+import json
+import random
+import sys
+import uuid
+from datetime import datetime, timedelta
+
+from database import get_db, init_db
+from services.redemption import generate_token
+
+
+SAMPLE_TAGS = ["rainy", "afternoon", "quiet_period", "cold", "weekend"]
+SAMPLE_GRADIENTS = [
+    ["#4A2C2A", "#D4A574"],
+    ["#1E3A8A", "#3B82F6"],
+    ["#7C2D12", "#F97316"],
+    ["#14532D", "#22C55E"],
+    ["#581C87", "#A855F7"],
+]
+
+
+async def seed_test_offers(session_id: str, count: int = 3):
+    await init_db()
+    db = await get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT id, name, category FROM merchants ORDER BY id LIMIT ?", (count,)
+        )
+        merchants = list(await cursor.fetchall())
+        if not merchants:
+            print("No merchants in DB. Run `python seed.py` first.")
+            return
+
+        print(f"Seeding {len(merchants)} accepted offers for session_id={session_id}")
+        print("-" * 76)
+
+        for i, m in enumerate(merchants):
+            offer_id = f"off_{uuid.uuid4().hex[:8]}"
+            token = generate_token()
+            gradient = SAMPLE_GRADIENTS[i % len(SAMPLE_GRADIENTS)]
+            style = {
+                "background_gradient": gradient,
+                "emoji": "*",
+                "tone": "warm",
+                "headline_style": "emotional",
+            }
+            tags = random.sample(SAMPLE_TAGS, 3)
+            expires_at = (datetime.now() + timedelta(minutes=30)).isoformat()
+
+            await db.execute(
+                """INSERT INTO offers (
+                    id, merchant_id, merchant_name, merchant_category,
+                    headline, subtext, description, discount_value, discount_type,
+                    context_tags, why_now, style, status, distance_meters,
+                    expires_at, redemption_token, user_session_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'accepted', ?, ?, ?, ?)""",
+                (
+                    offer_id,
+                    m["id"],
+                    m["name"],
+                    m["category"],
+                    f"15% off at {m['name']}",
+                    "Quiet afternoon, 2 min walk",
+                    "Seeded offer for end-to-end testing.",
+                    "15%",
+                    "percentage_discount",
+                    json.dumps(tags),
+                    "Seeded for demo flow",
+                    json.dumps(style),
+                    random.randint(50, 500),
+                    expires_at,
+                    token,
+                    session_id,
+                ),
+            )
+            print(f"OFFER {offer_id}  TOKEN {token}  MERCHANT {m['name']}")
+
+        await db.commit()
+        print("-" * 76)
+        print("Done. Visit /wallet on the frontend to see the offers.")
+    finally:
+        await db.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python seed_test_offers.py <session_id> [count]")
+        sys.exit(1)
+    sid = sys.argv[1]
+    n = int(sys.argv[2]) if len(sys.argv) > 2 else 3
+    asyncio.run(seed_test_offers(sid, n))

--- a/backend/services/redemption.py
+++ b/backend/services/redemption.py
@@ -1,0 +1,218 @@
+"""Redemption service: token generation, QR rendering, validation, commit, wallet."""
+
+import base64
+import io
+import json
+import logging
+import re
+import uuid
+from datetime import datetime
+from typing import Optional
+
+import aiosqlite
+import qrcode
+
+from models import Offer, OfferStatus, OfferStyle, MerchantCategory
+
+
+logger = logging.getLogger(__name__)
+
+ASSUMED_ORDER_TOTAL_USD = 15.00
+
+
+def generate_token() -> str:
+    """Return a UUID v4 string suitable for QR encoding and paste fallback."""
+    return str(uuid.uuid4())
+
+
+def generate_qr_png_base64(token: str) -> str:
+    """Render a QR encoding the token only (no host URL).
+
+    The QR is intentionally token-only so the same QR works regardless of where
+    the merchant scanner backend is hosted. The scanner extracts the raw token
+    and calls its configured backend with it.
+    """
+    img = qrcode.make(token, box_size=10, border=2)
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def compute_cashback(
+    discount_value: str,
+    discount_type: str,
+    order_total_usd: float = ASSUMED_ORDER_TOTAL_USD,
+) -> float:
+    """Convert a (value, type) pair to a dollar cashback estimate.
+
+    Returns 0.0 for unknown types or unparseable strings rather than raising,
+    so a redemption can still complete on malformed offer data.
+    """
+    if not discount_value:
+        return 0.0
+    try:
+        if discount_type == "percentage_discount":
+            match = re.search(r"(\d+(?:\.\d+)?)", discount_value)
+            if not match:
+                return 0.0
+            pct = float(match.group(1)) / 100.0
+            return round(order_total_usd * pct, 2)
+        if discount_type == "fixed_amount":
+            match = re.search(r"(\d+(?:\.\d+)?)", discount_value)
+            if not match:
+                return 0.0
+            return round(float(match.group(1)), 2)
+    except (ValueError, TypeError) as e:
+        logger.warning("compute_cashback failed for %r/%r: %s", discount_value, discount_type, e)
+    return 0.0
+
+
+def _parse_expires_at(value) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _row_to_offer(row: aiosqlite.Row) -> Offer:
+    """Hydrate an Offer from a SELECT * FROM offers row."""
+    raw_style = row["style"]
+    if isinstance(raw_style, str):
+        style_dict = json.loads(raw_style) if raw_style else {}
+    else:
+        style_dict = raw_style or {}
+
+    raw_tags = row["context_tags"]
+    if isinstance(raw_tags, str):
+        tags = json.loads(raw_tags) if raw_tags else []
+    else:
+        tags = raw_tags or []
+
+    return Offer(
+        id=row["id"],
+        merchant_id=row["merchant_id"],
+        merchant_name=row["merchant_name"],
+        merchant_category=MerchantCategory(row["merchant_category"]),
+        headline=row["headline"],
+        subtext=row["subtext"],
+        description=row["description"] or "",
+        discount_value=row["discount_value"] or "",
+        discount_type=row["discount_type"] or "",
+        context_tags=tags,
+        why_now=row["why_now"] or "",
+        created_at=_parse_expires_at(row["created_at"]) or datetime.now(),
+        expires_at=_parse_expires_at(row["expires_at"]) or datetime.now(),
+        style=OfferStyle(**style_dict) if style_dict else OfferStyle(
+            background_gradient=["#1A1A1A", "#1A1A1A"],
+            emoji="*",
+            tone="warm",
+            headline_style="factual",
+        ),
+        status=OfferStatus(row["status"] or "active"),
+        distance_meters=row["distance_meters"],
+        redemption_token=row["redemption_token"],
+    )
+
+
+async def lookup_offer_by_token(
+    db: aiosqlite.Connection, token: str
+) -> Optional[Offer]:
+    cursor = await db.execute(
+        "SELECT * FROM offers WHERE redemption_token = ? LIMIT 1", (token,)
+    )
+    row = await cursor.fetchone()
+    return _row_to_offer(row) if row else None
+
+
+async def validate_redemption(
+    db: aiosqlite.Connection,
+    token: str,
+    offer_id: Optional[str] = None,
+) -> tuple[bool, Optional[Offer], str]:
+    """Single source of truth for whether a token can be redeemed right now.
+
+    Returns (is_valid, offer, reason). On expiry, also updates the offer's
+    status to 'expired' so the next analytics call sees it correctly.
+    """
+    offer = await lookup_offer_by_token(db, token)
+    if offer is None:
+        return False, None, "Invalid token"
+
+    if offer_id is not None and offer.id != offer_id:
+        return False, None, "Token does not match offer"
+
+    if offer.status == OfferStatus.REDEEMED:
+        return False, offer, "Offer already redeemed"
+
+    if offer.status != OfferStatus.ACCEPTED:
+        return False, offer, f"Offer is not redeemable (status: {offer.status.value})"
+
+    if offer.expires_at and offer.expires_at <= datetime.now():
+        await db.execute(
+            "UPDATE offers SET status = 'expired' WHERE id = ?", (offer.id,)
+        )
+        await db.commit()
+        return False, offer, "Offer expired"
+
+    return True, offer, "OK"
+
+
+async def commit_redemption(
+    db: aiosqlite.Connection, offer: Offer
+) -> tuple[float, str]:
+    """Insert redemption row and mark offer redeemed. Returns (cashback, redemption_id)."""
+    cashback = compute_cashback(offer.discount_value, offer.discount_type)
+    redemption_id = f"rdm_{uuid.uuid4().hex[:8]}"
+
+    await db.execute(
+        "INSERT INTO redemptions (id, offer_id, token, cashback_amount) VALUES (?, ?, ?, ?)",
+        (redemption_id, offer.id, offer.redemption_token, cashback),
+    )
+    await db.execute(
+        "UPDATE offers SET status = 'redeemed' WHERE id = ?", (offer.id,)
+    )
+    await db.commit()
+    return cashback, redemption_id
+
+
+async def get_wallet_balance(db: aiosqlite.Connection, session_id: str) -> float:
+    cursor = await db.execute(
+        """SELECT COALESCE(SUM(r.cashback_amount), 0.0) AS balance
+           FROM redemptions r
+           JOIN offers o ON o.id = r.offer_id
+           WHERE o.user_session_id = ?""",
+        (session_id,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return 0.0
+    return round(float(row["balance"] or 0.0), 2)
+
+
+async def list_session_redemptions(
+    db: aiosqlite.Connection, session_id: str
+) -> list[dict]:
+    cursor = await db.execute(
+        """SELECT r.id, r.offer_id, r.cashback_amount, r.redeemed_at,
+                  o.merchant_name
+           FROM redemptions r
+           JOIN offers o ON o.id = r.offer_id
+           WHERE o.user_session_id = ?
+           ORDER BY r.redeemed_at DESC""",
+        (session_id,),
+    )
+    rows = await cursor.fetchall()
+    return [
+        {
+            "id": r["id"],
+            "offer_id": r["offer_id"],
+            "merchant_name": r["merchant_name"],
+            "cashback_amount": float(r["cashback_amount"] or 0.0),
+            "redeemed_at": str(r["redeemed_at"]),
+        }
+        for r in rows
+    ]

--- a/backend/services/redemption.py
+++ b/backend/services/redemption.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 import aiosqlite
@@ -67,15 +67,26 @@ def compute_cashback(
     return 0.0
 
 
+def _utcnow() -> datetime:
+    """Aware UTC now. All timestamps in this module live in UTC."""
+    return datetime.now(timezone.utc)
+
+
 def _parse_expires_at(value) -> Optional[datetime]:
+    """Parse a stored timestamp as an aware UTC datetime.
+
+    SQLite stores CURRENT_TIMESTAMP as a naive UTC string. Anything that comes
+    back without tzinfo is assumed to be UTC.
+    """
     if value is None:
         return None
     if isinstance(value, datetime):
-        return value
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
     try:
-        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
     except ValueError:
         return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
 
 
 def _row_to_offer(row: aiosqlite.Row) -> Offer:
@@ -104,8 +115,8 @@ def _row_to_offer(row: aiosqlite.Row) -> Offer:
         discount_type=row["discount_type"] or "",
         context_tags=tags,
         why_now=row["why_now"] or "",
-        created_at=_parse_expires_at(row["created_at"]) or datetime.now(),
-        expires_at=_parse_expires_at(row["expires_at"]) or datetime.now(),
+        created_at=_parse_expires_at(row["created_at"]) or _utcnow(),
+        expires_at=_parse_expires_at(row["expires_at"]) or _utcnow(),
         style=OfferStyle(**style_dict) if style_dict else OfferStyle(
             background_gradient=["#1A1A1A", "#1A1A1A"],
             emoji="*",
@@ -151,7 +162,7 @@ async def validate_redemption(
     if offer.status != OfferStatus.ACCEPTED:
         return False, offer, f"Offer is not redeemable (status: {offer.status.value})"
 
-    if offer.expires_at and offer.expires_at <= datetime.now():
+    if offer.expires_at and offer.expires_at <= _utcnow():
         await db.execute(
             "UPDATE offers SET status = 'expired' WHERE id = ?", (offer.id,)
         )
@@ -163,20 +174,31 @@ async def validate_redemption(
 
 async def commit_redemption(
     db: aiosqlite.Connection, offer: Offer
-) -> tuple[float, str]:
-    """Insert redemption row and mark offer redeemed. Returns (cashback, redemption_id)."""
+) -> tuple[bool, float, Optional[str]]:
+    """Atomically claim the offer and record the redemption.
+
+    Returns (committed, cashback, redemption_id). committed=False means another
+    request beat us to it; the caller should treat this as 'already redeemed'
+    rather than as success. We claim by updating WHERE status='accepted', so
+    concurrent calls cannot both succeed.
+    """
     cashback = compute_cashback(offer.discount_value, offer.discount_type)
     redemption_id = f"rdm_{uuid.uuid4().hex[:8]}"
+
+    cursor = await db.execute(
+        "UPDATE offers SET status = 'redeemed' WHERE id = ? AND status = 'accepted'",
+        (offer.id,),
+    )
+    if cursor.rowcount != 1:
+        await db.rollback()
+        return False, 0.0, None
 
     await db.execute(
         "INSERT INTO redemptions (id, offer_id, token, cashback_amount) VALUES (?, ?, ?, ?)",
         (redemption_id, offer.id, offer.redemption_token, cashback),
     )
-    await db.execute(
-        "UPDATE offers SET status = 'redeemed' WHERE id = ?", (offer.id,)
-    )
     await db.commit()
-    return cashback, redemption_id
+    return True, cashback, redemption_id
 
 
 async def get_wallet_balance(db: aiosqlite.Connection, session_id: str) -> float:

--- a/docs/checkout-redemption.md
+++ b/docs/checkout-redemption.md
@@ -22,11 +22,12 @@ Offer status -> "accepted"
     |
     v
 User navigates to /redeem/{offer_id}
-Frontend displays QR code encoding: {base_url}/api/redeem/validate/{token}
+Frontend fetches GET /api/redeem/qr/{offer_id}
+Backend renders QR encoding the raw token (no URL, deploy-portable)
     |
     v
 Merchant opens /merchant/scan on their device
-Camera scans QR code
+Camera scans QR code (or merchant pastes the token as a fallback)
     |
     v
 Frontend calls GET /api/redeem/validate/{token}
@@ -65,27 +66,39 @@ For a hackathon, UUID v4 tokens provide sufficient uniqueness and unpredictabili
 - Rate limiting on validation endpoint
 - Time-based expiry enforcement on the server
 
+### Atomic Redeem
+
+`commit_redemption` claims the offer with a single conditional update:
+
+```sql
+UPDATE offers SET status = 'redeemed' WHERE id = ? AND status = 'accepted'
+```
+
+It only inserts into `redemptions` if `rowcount == 1`. Two concurrent `POST /api/redeem` calls on the same token cannot both succeed. The losing call returns `success=false, message="Offer already redeemed"`.
+
+### Datetime Convention
+
+All timestamps are UTC. SQLite's `CURRENT_TIMESTAMP` is naive UTC; the redemption service parses stored timestamps as aware UTC and uses `datetime.now(timezone.utc)` for comparisons. Do not introduce `datetime.now()` (local-time, naive) anywhere in this module.
+
 ---
 
 ## QR Code Generation
 
 **Implementation:** `backend/services/redemption.py`
 
-The QR code is generated server-side using Python's `qrcode` library and returned as a base64-encoded PNG.
+The QR code is generated server-side using Python's `qrcode` library and returned as a base64-encoded PNG via `GET /api/redeem/qr/{offer_id}`.
 
 ```python
 import qrcode
 import io
 import base64
 
-def generate_qr_code(token: str, base_url: str) -> str:
-    """Generate a QR code that encodes the validation URL."""
-    url = f"{base_url}/api/redeem/validate/{token}"
-    qr = qrcode.make(url)
-    buffer = io.BytesIO()
-    qr.save(buffer, format="PNG")
-    buffer.seek(0)
-    return base64.b64encode(buffer.read()).decode("utf-8")
+def generate_qr_png_base64(token: str) -> str:
+    """Render a QR encoding the token only (no host URL)."""
+    img = qrcode.make(token, box_size=10, border=2)
+    buf = io.BytesIO()
+    img.save(buf, "PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
 ```
 
 The frontend displays this as:
@@ -95,12 +108,12 @@ The frontend displays this as:
 
 ### What the QR Encodes
 
-The QR code contains a URL:
+The QR encodes the raw UUID token only, not a URL:
 ```
-http://localhost:8000/api/redeem/validate/a7f3b2c1-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+a7f3b2c1-4d5e-6f7a-8b9c-0d1e2f3a4b5c
 ```
 
-When the merchant scans this with their phone camera (or the in-app scanner), it opens the validation endpoint. The merchant dashboard at `/merchant/scan` uses a camera-based QR scanner component that reads this URL, extracts the token, and calls the validation API.
+This keeps the demo deploy-portable: the merchant scanner is responsible for calling its configured backend with the scanned token, so the same QR works whether the backend is on localhost, a tunnel, or production. The merchant page at `/merchant/scan` uses `html5-qrcode` to read the token, then calls the validate and redeem endpoints. A paste-token textbox is provided as a fallback for when the camera is unavailable (browser permissions denied, no camera, demo on a desktop).
 
 ---
 
@@ -230,6 +243,6 @@ active ---+------+---> expired (time ran out)
 | `frontend/src/app/wallet/page.tsx` | Consumer wallet (accepted/redeemed offers) |
 | `frontend/src/app/merchant/page.tsx` | Merchant dashboard with analytics |
 | `frontend/src/app/merchant/scan/page.tsx` | Merchant QR scanner |
-| `frontend/src/components/QRCode.tsx` | QR code display component |
-| `frontend/src/components/QRScanner.tsx` | Camera-based QR scanning component |
-| `frontend/src/components/PerformanceChart.tsx` | Analytics chart for merchant dashboard |
+| `frontend/src/components/QRDisplay.tsx` | QR code display component (fetches base64 PNG from backend) |
+| `frontend/src/components/QRScanner.tsx` | Camera-based QR scanning component (html5-qrcode) |
+| `frontend/src/components/CashbackBalance.tsx` | Wallet balance card |

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,13 +8,16 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "html5-qrcode": "^2.3.8",
         "next": "16.2.4",
+        "qrcode": "^1.5.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -1641,6 +1644,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2289,11 +2302,19 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2672,6 +2693,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -2715,11 +2745,21 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2732,7 +2772,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2850,6 +2889,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2902,6 +2950,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3767,6 +3821,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4011,6 +4074,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html5-qrcode": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/html5-qrcode/-/html5-qrcode-2.3.8.tgz",
+      "integrity": "sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4245,6 +4314,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -5379,6 +5457,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5396,7 +5483,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5436,6 +5522,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -5507,6 +5602,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/queue-microtask": {
@@ -5601,6 +5713,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -5751,6 +5878,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5988,6 +6121,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -6099,6 +6252,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -6614,6 +6779,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -6646,12 +6817,119 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,13 +9,16 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "html5-qrcode": "^2.3.8",
     "next": "16.2.4",
+    "qrcode": "^1.5.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/frontend/src/app/merchant/page.tsx
+++ b/frontend/src/app/merchant/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+import BottomNav from "@/components/BottomNav";
+import { getMerchantAnalytics, getMerchants } from "@/lib/api";
+import type { Merchant, OfferAnalytics } from "@/lib/types";
+
+function StatCard({
+  label,
+  value,
+  sub,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-2xl bg-[#1A1A1A] p-4">
+      <p className="text-xs uppercase tracking-wider text-white/50">{label}</p>
+      <p className="mt-1 text-2xl font-bold tabular-nums text-white">{value}</p>
+      {sub && <p className="mt-1 text-xs text-white/60">{sub}</p>}
+    </div>
+  );
+}
+
+export default function MerchantDashboardPage() {
+  const [merchants, setMerchants] = useState<Merchant[]>([]);
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [analytics, setAnalytics] = useState<OfferAnalytics | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    getMerchants()
+      .then((res) => {
+        setMerchants(res.merchants);
+        if (res.merchants.length > 0) setSelectedId(res.merchants[0].id);
+      })
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedId) return;
+    setAnalytics(null);
+    getMerchantAnalytics(selectedId)
+      .then(setAnalytics)
+      .catch((e: Error) => setError(e.message));
+  }, [selectedId]);
+
+  const fmtPct = (n: number) => `${(n * 100).toFixed(0)}%`;
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="px-5 pt-8 pb-4">
+        <h1 className="text-2xl font-bold text-white">Merchant dashboard</h1>
+        <p className="text-sm text-white/60">Offer performance and redemptions</p>
+      </header>
+
+      <div className="space-y-5 px-5">
+        {merchants.length > 0 && (
+          <select
+            value={selectedId}
+            onChange={(e) => setSelectedId(e.target.value)}
+            className="w-full rounded-2xl bg-[#1A1A1A] px-4 py-3 text-sm text-white outline-none ring-1 ring-white/10 focus:ring-blue-400/50"
+          >
+            {merchants.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        )}
+
+        {error && (
+          <div className="rounded-2xl bg-red-500/10 p-4 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+
+        {!analytics && !error && (
+          <div className="grid grid-cols-2 gap-3">
+            <div className="h-24 animate-pulse rounded-2xl bg-[#1A1A1A]" />
+            <div className="h-24 animate-pulse rounded-2xl bg-[#1A1A1A]" />
+            <div className="h-24 animate-pulse rounded-2xl bg-[#1A1A1A]" />
+            <div className="h-24 animate-pulse rounded-2xl bg-[#1A1A1A]" />
+          </div>
+        )}
+
+        {analytics && (
+          <>
+            <div className="grid grid-cols-2 gap-3">
+              <StatCard label="Generated" value={String(analytics.total_generated)} />
+              <StatCard
+                label="Accepted"
+                value={String(analytics.total_accepted)}
+                sub={`${fmtPct(analytics.acceptance_rate)} acceptance`}
+              />
+              <StatCard
+                label="Redeemed"
+                value={String(analytics.total_redeemed)}
+                sub={`${fmtPct(analytics.redemption_rate)} redemption`}
+              />
+              <StatCard
+                label="Revenue impact"
+                value={`$${analytics.revenue_impact_estimate.toFixed(2)}`}
+              />
+            </div>
+
+            <div className="rounded-2xl bg-[#1A1A1A] p-5">
+              <p className="mb-3 text-xs uppercase tracking-wider text-white/50">
+                Top context triggers
+              </p>
+              {analytics.top_context_triggers.length === 0 ? (
+                <p className="text-sm text-white/50">No data yet</p>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {analytics.top_context_triggers.map((tag) => (
+                    <span
+                      key={tag}
+                      className="rounded-full bg-blue-500/10 px-3 py-1 text-xs font-medium text-blue-300"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-2xl bg-[#1A1A1A] p-4 text-center">
+                <p className="text-xs uppercase tracking-wider text-white/50">Declined</p>
+                <p className="mt-1 text-xl font-semibold tabular-nums text-white/80">
+                  {analytics.total_declined}
+                </p>
+              </div>
+              <div className="rounded-2xl bg-[#1A1A1A] p-4 text-center">
+                <p className="text-xs uppercase tracking-wider text-white/50">Expired</p>
+                <p className="mt-1 text-xl font-semibold tabular-nums text-white/80">
+                  {analytics.total_expired}
+                </p>
+              </div>
+            </div>
+
+            {analytics.total_generated === 0 && (
+              <div className="rounded-2xl bg-[#1A1A1A] p-5 text-sm text-white/60">
+                No offers generated yet for this merchant. To test the redemption flow,
+                run from the backend directory:{" "}
+                <code className="block mt-2 rounded bg-black/40 px-2 py-1 font-mono text-xs">
+                  python seed_test_offers.py &lt;session_id&gt;
+                </code>
+              </div>
+            )}
+          </>
+        )}
+
+        <Link
+          href="/merchant/scan"
+          className="block rounded-2xl bg-emerald-500 px-5 py-4 text-center text-sm font-semibold text-black hover:bg-emerald-400"
+        >
+          Scan QR to redeem
+        </Link>
+      </div>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/frontend/src/app/merchant/scan/page.tsx
+++ b/frontend/src/app/merchant/scan/page.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+
+import QRScanner from "@/components/QRScanner";
+import { redeemOffer, validateToken } from "@/lib/api";
+import type { Offer, RedemptionResult, TokenValidationResponse } from "@/lib/types";
+
+type ScanState =
+  | { phase: "scanning"; cameraError: string | null }
+  | { phase: "previewing"; offer: Offer; token: string }
+  | { phase: "success"; result: RedemptionResult }
+  | { phase: "error"; message: string };
+
+export default function MerchantScanPage() {
+  const [state, setState] = useState<ScanState>({ phase: "scanning", cameraError: null });
+  const [pasteValue, setPasteValue] = useState("");
+  const [validating, setValidating] = useState(false);
+
+  const handleToken = useCallback(async (token: string) => {
+    if (!token) return;
+    setValidating(true);
+    try {
+      const res: TokenValidationResponse = await validateToken(token);
+      if (!res.valid || !res.offer) {
+        setState({ phase: "error", message: "Invalid or expired token." });
+        return;
+      }
+      setState({ phase: "previewing", offer: res.offer, token });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Validation failed";
+      setState({ phase: "error", message: msg });
+    } finally {
+      setValidating(false);
+    }
+  }, []);
+
+  const handleConfirm = async () => {
+    if (state.phase !== "previewing") return;
+    try {
+      const result = await redeemOffer(state.offer.id, state.token);
+      if (!result.success) {
+        setState({ phase: "error", message: result.message });
+        return;
+      }
+      setState({ phase: "success", result });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Redemption failed";
+      setState({ phase: "error", message: msg });
+    }
+  };
+
+  const reset = () => {
+    setPasteValue("");
+    setState({ phase: "scanning", cameraError: null });
+  };
+
+  return (
+    <div className="min-h-screen px-5 py-8">
+      <header className="mx-auto mb-6 flex max-w-md items-center justify-between">
+        <Link href="/merchant" className="text-sm text-white/60 hover:text-white">
+          Back to dashboard
+        </Link>
+        <h1 className="text-lg font-semibold text-white">Scan</h1>
+        <span className="w-24" />
+      </header>
+
+      <div className="mx-auto max-w-md space-y-5">
+        {state.phase === "scanning" && (
+          <>
+            <QRScanner
+              onScan={handleToken}
+              onError={(err) =>
+                setState({ phase: "scanning", cameraError: err })
+              }
+            />
+
+            <div className="rounded-2xl bg-[#1A1A1A] p-4">
+              <label className="mb-2 block text-xs uppercase tracking-wider text-white/50">
+                Or paste token
+              </label>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={pasteValue}
+                  onChange={(e) => setPasteValue(e.target.value)}
+                  placeholder="Paste token here"
+                  className="flex-1 rounded-lg bg-black/40 px-3 py-2 font-mono text-sm text-white outline-none ring-1 ring-white/10 focus:ring-blue-400/50"
+                />
+                <button
+                  onClick={() => handleToken(pasteValue.trim())}
+                  disabled={!pasteValue.trim() || validating}
+                  className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-black disabled:opacity-50"
+                >
+                  Validate
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {state.phase === "previewing" && (
+          <div className="space-y-4 rounded-2xl bg-[#1A1A1A] p-6">
+            <div>
+              <p className="text-xs uppercase tracking-wider text-white/50">
+                {state.offer.merchant_name}
+              </p>
+              <h2 className="mt-1 text-xl font-bold text-white">
+                {state.offer.headline}
+              </h2>
+              <p className="mt-1 text-sm text-white/70">{state.offer.subtext}</p>
+            </div>
+            <span className="inline-block rounded-full border border-blue-400/40 px-3 py-1 text-sm font-semibold text-blue-300">
+              {state.offer.discount_value}
+            </span>
+            <div className="flex gap-3 pt-2">
+              <button
+                onClick={handleConfirm}
+                className="flex-1 rounded-full bg-emerald-500 px-5 py-3 text-sm font-semibold text-black hover:bg-emerald-400"
+              >
+                Confirm Redemption
+              </button>
+              <button
+                onClick={reset}
+                className="rounded-full bg-white/10 px-5 py-3 text-sm font-semibold text-white hover:bg-white/20"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {state.phase === "success" && (
+          <div className="rounded-2xl bg-emerald-500/10 p-8 text-center">
+            <div className="mx-auto mb-3 flex h-16 w-16 items-center justify-center rounded-full bg-emerald-500/20 text-3xl text-emerald-300">
+              v
+            </div>
+            <p className="text-lg font-semibold text-white">{state.result.message}</p>
+            {state.result.cashback_amount != null && (
+              <p className="mt-2 text-3xl font-bold tabular-nums text-emerald-400">
+                +${state.result.cashback_amount.toFixed(2)}
+              </p>
+            )}
+            <button
+              onClick={reset}
+              className="mt-6 rounded-full bg-white px-5 py-2 text-sm font-semibold text-black"
+            >
+              Scan another
+            </button>
+          </div>
+        )}
+
+        {state.phase === "error" && (
+          <div className="rounded-2xl bg-red-500/10 p-8 text-center">
+            <p className="text-lg font-semibold text-red-300">{state.message}</p>
+            <button
+              onClick={reset}
+              className="mt-5 rounded-full bg-white px-5 py-2 text-sm font-semibold text-black"
+            >
+              Try again
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/redeem/[id]/page.tsx
+++ b/frontend/src/app/redeem/[id]/page.tsx
@@ -36,6 +36,14 @@ export default function RedeemPage() {
     const sid = getSessionId();
     if (!sid || !offerId) return;
     let alive = true;
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    const stop = () => {
+      if (interval !== null) {
+        clearInterval(interval);
+        interval = null;
+      }
+    };
 
     const fetchOffer = async () => {
       try {
@@ -43,7 +51,8 @@ export default function RedeemPage() {
         const found = res.offers.find((o) => o.id === offerId) ?? null;
         if (!alive) return;
         setOffer(found);
-        if (found?.status === "redeemed" && cashback === null) {
+        if (found?.status === "redeemed") {
+          stop();
           const wallet = await getWalletBalance(sid);
           if (!alive) return;
           const matched = wallet.redemptions.find((r) => r.offer_id === offerId);
@@ -55,16 +64,13 @@ export default function RedeemPage() {
     };
 
     fetchOffer();
-    const interval = setInterval(() => {
-      if (!alive) return;
-      fetchOffer();
-    }, POLL_INTERVAL_MS);
+    interval = setInterval(fetchOffer, POLL_INTERVAL_MS);
 
     return () => {
       alive = false;
-      clearInterval(interval);
+      stop();
     };
-  }, [offerId, cashback]);
+  }, [offerId]);
 
   useEffect(() => {
     const t = setInterval(() => setTick((n) => n + 1), 1000);

--- a/frontend/src/app/redeem/[id]/page.tsx
+++ b/frontend/src/app/redeem/[id]/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+
+import QRDisplay from "@/components/QRDisplay";
+import { getOffers, getWalletBalance } from "@/lib/api";
+import { getSessionId } from "@/lib/session";
+import type { Offer } from "@/lib/types";
+
+const POLL_INTERVAL_MS = 2000;
+
+function formatRemaining(expiresAt: string | null): { label: string; danger: boolean; expired: boolean } {
+  if (!expiresAt) return { label: "", danger: false, expired: false };
+  const diff = new Date(expiresAt).getTime() - Date.now();
+  if (diff <= 0) return { label: "Expired", danger: true, expired: true };
+  const totalSeconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return {
+    label: `${minutes}:${seconds.toString().padStart(2, "0")}`,
+    danger: minutes < 5,
+    expired: false,
+  };
+}
+
+export default function RedeemPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const offerId = params.id;
+  const [offer, setOffer] = useState<Offer | null>(null);
+  const [cashback, setCashback] = useState<number | null>(null);
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const sid = getSessionId();
+    if (!sid || !offerId) return;
+    let alive = true;
+
+    const fetchOffer = async () => {
+      try {
+        const res = await getOffers(sid);
+        const found = res.offers.find((o) => o.id === offerId) ?? null;
+        if (!alive) return;
+        setOffer(found);
+        if (found?.status === "redeemed" && cashback === null) {
+          const wallet = await getWalletBalance(sid);
+          if (!alive) return;
+          const matched = wallet.redemptions.find((r) => r.offer_id === offerId);
+          setCashback(matched?.cashback_amount ?? 0);
+        }
+      } catch {
+        // network blip; keep last known offer state
+      }
+    };
+
+    fetchOffer();
+    const interval = setInterval(() => {
+      if (!alive) return;
+      fetchOffer();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      alive = false;
+      clearInterval(interval);
+    };
+  }, [offerId, cashback]);
+
+  useEffect(() => {
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const remaining = formatRemaining(offer?.expires_at ?? null);
+  void tick;
+  const isRedeemed = offer?.status === "redeemed";
+
+  return (
+    <div className="min-h-screen px-6 py-8">
+      <button
+        onClick={() => router.push("/wallet")}
+        className="mb-6 text-sm text-white/60 hover:text-white"
+      >
+        Back to wallet
+      </button>
+
+      {offer && isRedeemed ? (
+        <div className="mx-auto flex max-w-md flex-col items-center text-center animate-fade-in">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full bg-emerald-500/20 text-4xl text-emerald-300">
+            v
+          </div>
+          <h1 className="mt-5 text-3xl font-bold text-white">Redeemed!</h1>
+          <p className="mt-2 text-sm text-white/60">
+            at {offer.merchant_name}
+          </p>
+          {cashback !== null && (
+            <p className="mt-6 text-4xl font-bold tabular-nums text-emerald-400">
+              +${cashback.toFixed(2)}
+            </p>
+          )}
+          <p className="mt-1 text-sm text-white/50">cashback applied</p>
+          <button
+            onClick={() => router.push("/wallet")}
+            className="mt-8 rounded-full bg-white px-6 py-3 text-sm font-semibold text-black hover:scale-105 active:scale-95 transition-transform"
+          >
+            Back to wallet
+          </button>
+        </div>
+      ) : offer ? (
+        <div className="mx-auto flex max-w-md flex-col items-center text-center">
+          <p className="text-xs uppercase tracking-wider text-white/50">
+            {offer.merchant_name}
+          </p>
+          <h1 className="mt-1 text-2xl font-bold text-white">{offer.headline}</h1>
+          <span className="mt-3 inline-block rounded-full border border-blue-400/40 px-3 py-1 text-sm font-semibold text-blue-300">
+            {offer.discount_value}
+          </span>
+
+          <div className="mt-8">
+            <QRDisplay offerId={offerId} size={280} />
+          </div>
+
+          <p className="mt-6 text-sm text-white/70">
+            Show this to the cashier
+          </p>
+          <p
+            className={`mt-2 text-sm tabular-nums ${
+              remaining.expired
+                ? "text-red-400"
+                : remaining.danger
+                  ? "text-amber-300"
+                  : "text-white/50"
+            }`}
+          >
+            {remaining.expired ? "Expired" : `Expires in ${remaining.label}`}
+          </p>
+          <p className="mt-1 text-xs text-white/30">
+            Waiting for merchant scan...
+          </p>
+        </div>
+      ) : (
+        <div className="mx-auto max-w-md text-center text-white/60">
+          Loading offer...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/wallet/page.tsx
+++ b/frontend/src/app/wallet/page.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+import BottomNav from "@/components/BottomNav";
+import CashbackBalance from "@/components/CashbackBalance";
+import OfferCard from "@/components/OfferCard";
+import { getOffers, getWalletBalance, type WalletRedemption } from "@/lib/api";
+import { getSessionId } from "@/lib/session";
+import type { Offer } from "@/lib/types";
+
+export default function WalletPage() {
+  const router = useRouter();
+  const [offers, setOffers] = useState<Offer[] | null>(null);
+  const [balance, setBalance] = useState(0);
+  const [redemptionCount, setRedemptionCount] = useState(0);
+  const [redemptions, setRedemptions] = useState<WalletRedemption[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const sid = getSessionId();
+    if (!sid) return;
+    Promise.all([getOffers(sid), getWalletBalance(sid)])
+      .then(([offersRes, walletRes]) => {
+        setOffers(offersRes.offers);
+        setBalance(walletRes.balance_usd);
+        setRedemptionCount(walletRes.redemption_count);
+        setRedemptions(walletRes.redemptions);
+      })
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  const accepted = offers?.filter((o) => o.status === "accepted") ?? [];
+  const redeemed = offers?.filter((o) => o.status === "redeemed") ?? [];
+  const expired = offers?.filter((o) => o.status === "expired") ?? [];
+
+  const cashbackByOfferId = new Map(
+    redemptions.map((r) => [r.offer_id, r.cashback_amount]),
+  );
+
+  return (
+    <div className="min-h-screen pb-24">
+      <header className="px-5 pt-8 pb-4">
+        <h1 className="text-2xl font-bold text-white">Wallet</h1>
+        <p className="text-sm text-white/60">Your accepted offers and cashback</p>
+      </header>
+
+      <div className="space-y-6 px-5">
+        <CashbackBalance balanceUsd={balance} redemptionCount={redemptionCount} />
+
+        {error && (
+          <div className="rounded-2xl bg-red-500/10 p-4 text-sm text-red-300">
+            {error}
+          </div>
+        )}
+
+        {offers === null && !error && (
+          <div className="space-y-3">
+            <div className="h-32 animate-pulse rounded-2xl bg-[#1A1A1A]" />
+            <div className="h-32 animate-pulse rounded-2xl bg-[#1A1A1A]" />
+          </div>
+        )}
+
+        {offers !== null && offers.length === 0 && (
+          <div className="rounded-2xl bg-[#1A1A1A] p-6 text-center">
+            <p className="mb-3 text-white/70">No offers yet.</p>
+            <Link
+              href="/"
+              className="inline-block rounded-full bg-white px-5 py-2 text-sm font-semibold text-black"
+            >
+              Discover offers
+            </Link>
+          </div>
+        )}
+
+        {accepted.length > 0 && (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-white/50">
+              Ready to use
+            </h2>
+            <div className="space-y-3">
+              {accepted.map((o) => (
+                <OfferCard
+                  key={o.id}
+                  offer={o}
+                  onShowQR={(id) => router.push(`/redeem/${id}`)}
+                />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {redeemed.length > 0 && (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-white/50">
+              Redeemed
+            </h2>
+            <div className="space-y-2">
+              {redeemed.map((o) => {
+                const cashback = cashbackByOfferId.get(o.id) ?? 0;
+                return (
+                  <div
+                    key={o.id}
+                    className="flex items-center justify-between rounded-2xl bg-[#1A1A1A] p-4"
+                  >
+                    <div>
+                      <p className="font-semibold text-white">{o.merchant_name}</p>
+                      <p className="text-xs text-white/50">{o.headline}</p>
+                    </div>
+                    <p className="font-bold tabular-nums text-emerald-400">
+                      +${cashback.toFixed(2)}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
+
+        {expired.length > 0 && (
+          <section>
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-white/40">
+              Expired
+            </h2>
+            <div className="space-y-2 opacity-60">
+              {expired.map((o) => (
+                <div
+                  key={o.id}
+                  className="rounded-2xl bg-[#1A1A1A] p-4 text-sm text-white/60"
+                >
+                  <span className="font-semibold">{o.merchant_name}</span>
+                  <span className="ml-2 text-white/40">{o.headline}</span>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </div>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/frontend/src/components/CashbackBalance.tsx
+++ b/frontend/src/components/CashbackBalance.tsx
@@ -1,0 +1,23 @@
+interface CashbackBalanceProps {
+  balanceUsd: number;
+  redemptionCount: number;
+}
+
+export default function CashbackBalance({
+  balanceUsd,
+  redemptionCount,
+}: CashbackBalanceProps) {
+  return (
+    <div className="rounded-2xl bg-[#1A1A1A] p-5">
+      <p className="text-xs uppercase tracking-wider text-white/50">
+        Wallet balance
+      </p>
+      <p className="mt-1 text-3xl font-bold tabular-nums text-emerald-400">
+        ${balanceUsd.toFixed(2)}
+      </p>
+      <p className="mt-1 text-sm text-white/60">
+        {redemptionCount} {redemptionCount === 1 ? "redemption" : "redemptions"}
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/OfferCard.tsx
+++ b/frontend/src/components/OfferCard.tsx
@@ -4,6 +4,7 @@ interface OfferCardProps {
   offer: Offer;
   onAccept?: (id: string) => void;
   onDismiss?: (id: string) => void;
+  onShowQR?: (id: string) => void;
 }
 
 function getTimeRemaining(expiresAt: string): string {
@@ -20,7 +21,7 @@ const toneClasses: Record<string, string> = {
   sophisticated: "animate-fade-in",
 };
 
-export default function OfferCard({ offer, onAccept, onDismiss }: OfferCardProps) {
+export default function OfferCard({ offer, onAccept, onDismiss, onShowQR }: OfferCardProps) {
   const gradient = `linear-gradient(135deg, ${offer.style.background_gradient[0]}, ${offer.style.background_gradient[1]})`;
   const timeLeft = getTimeRemaining(offer.expires_at);
   const isExpired = timeLeft === "Expired";
@@ -68,9 +69,18 @@ export default function OfferCard({ offer, onAccept, onDismiss }: OfferCardProps
             Accept
           </button>
         ) : offer.status === "accepted" ? (
-          <span className="rounded-full bg-emerald-500/20 border border-emerald-400/50 px-4 py-2 text-sm font-semibold text-emerald-300">
-            Accepted
-          </span>
+          onShowQR ? (
+            <button
+              onClick={() => onShowQR(offer.id)}
+              className="rounded-full bg-white px-5 py-2 text-sm font-semibold text-black transition-transform hover:scale-105 active:scale-95"
+            >
+              Show QR
+            </button>
+          ) : (
+            <span className="rounded-full bg-emerald-500/20 border border-emerald-400/50 px-4 py-2 text-sm font-semibold text-emerald-300">
+              Accepted
+            </span>
+          )
         ) : (
           <span className="text-sm text-white/50">Expired</span>
         )}

--- a/frontend/src/components/QRDisplay.tsx
+++ b/frontend/src/components/QRDisplay.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getOfferQR } from "@/lib/api";
+
+interface QRDisplayProps {
+  offerId: string;
+  size?: number;
+}
+
+interface QRData {
+  qr_base64: string;
+  token: string;
+  expires_at: string;
+}
+
+export default function QRDisplay({ offerId, size = 280 }: QRDisplayProps) {
+  const [data, setData] = useState<QRData | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setData(null);
+    setError(null);
+    getOfferQR(offerId)
+      .then((d) => {
+        if (alive) setData(d);
+      })
+      .catch((e: Error) => {
+        if (alive) setError(e.message || "Failed to load QR");
+      });
+    return () => {
+      alive = false;
+    };
+  }, [offerId]);
+
+  if (error) {
+    return (
+      <div
+        className="flex flex-col items-center justify-center rounded-2xl bg-[#1A1A1A] p-6 text-center"
+        style={{ width: size, height: size }}
+      >
+        <p className="mb-3 text-sm text-red-300">{error}</p>
+        <button
+          onClick={() => {
+            setError(null);
+            setData(null);
+            getOfferQR(offerId).then(setData).catch((e) => setError(e.message));
+          }}
+          className="rounded-full bg-white px-4 py-1.5 text-xs font-semibold text-black"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div
+        className="animate-pulse rounded-2xl bg-[#1A1A1A]"
+        style={{ width: size, height: size }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <div
+        className="rounded-2xl bg-white p-3"
+        style={{ width: size, height: size }}
+      >
+        <img
+          src={`data:image/png;base64,${data.qr_base64}`}
+          alt="Redemption QR code"
+          className="h-full w-full object-contain"
+        />
+      </div>
+      <code className="select-all break-all rounded-lg bg-[#1A1A1A] px-3 py-2 font-mono text-xs text-white/70">
+        {data.token}
+      </code>
+    </div>
+  );
+}

--- a/frontend/src/components/QRScanner.tsx
+++ b/frontend/src/components/QRScanner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+interface QRScannerProps {
+  onScan: (token: string) => void;
+  onError?: (err: string) => void;
+}
+
+const REGION_ID = "qr-scanner-region";
+
+export default function QRScanner({ onScan, onError }: QRScannerProps) {
+  const startedRef = useRef(false);
+  const [permissionState, setPermissionState] = useState<"pending" | "ok" | "error">("pending");
+
+  useEffect(() => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+
+    let scannerInstance: { stop: () => Promise<void>; clear: () => void } | null = null;
+    let cancelled = false;
+
+    import("html5-qrcode")
+      .then(({ Html5Qrcode }) => {
+        if (cancelled) return;
+        const scanner = new Html5Qrcode(REGION_ID);
+        scannerInstance = scanner as unknown as typeof scannerInstance;
+        return scanner
+          .start(
+            { facingMode: "environment" },
+            { fps: 10, qrbox: { width: 240, height: 240 } },
+            (decodedText: string) => {
+              const token = decodedText.includes("/")
+                ? decodedText.split("/").pop() || decodedText
+                : decodedText.trim();
+              onScan(token);
+            },
+            () => {
+              // per-frame "no qr" callback; ignore
+            },
+          )
+          .then(() => {
+            if (!cancelled) setPermissionState("ok");
+          });
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        setPermissionState("error");
+        onError?.(err.message || "Camera unavailable");
+      });
+
+    return () => {
+      cancelled = true;
+      if (scannerInstance) {
+        scannerInstance
+          .stop()
+          .then(() => scannerInstance?.clear())
+          .catch(() => {});
+      }
+    };
+  }, [onScan, onError]);
+
+  return (
+    <div className="w-full">
+      <div
+        id={REGION_ID}
+        className="mx-auto w-full max-w-md overflow-hidden rounded-2xl bg-black"
+        style={{ minHeight: 280 }}
+      />
+      {permissionState === "error" && (
+        <p className="mt-3 text-center text-xs text-white/60">
+          Camera unavailable. Use the paste field below.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -109,3 +109,27 @@ export async function validateToken(
 ): Promise<TokenValidationResponse> {
   return request(`/redeem/validate/${encodeURIComponent(token)}`);
 }
+
+export async function getOfferQR(offerId: string): Promise<{
+  qr_base64: string;
+  token: string;
+  expires_at: string;
+}> {
+  return request(`/redeem/qr/${encodeURIComponent(offerId)}`);
+}
+
+export interface WalletRedemption {
+  id: string;
+  offer_id: string;
+  merchant_name: string;
+  cashback_amount: number;
+  redeemed_at: string;
+}
+
+export async function getWalletBalance(sessionId: string): Promise<{
+  balance_usd: number;
+  redemption_count: number;
+  redemptions: WalletRedemption[];
+}> {
+  return request(`/wallet/${encodeURIComponent(sessionId)}`);
+}

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,0 +1,15 @@
+const KEY = "city_wallet_session_id";
+
+export function getSessionId(): string {
+  if (typeof window === "undefined") return "";
+  const existing = window.localStorage.getItem(KEY);
+  if (existing) return existing;
+  const fresh = crypto.randomUUID();
+  window.localStorage.setItem(KEY, fresh);
+  return fresh;
+}
+
+export function resetSessionId(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(KEY);
+}


### PR DESCRIPTION
## Summary

- Backend: redemption service (UUID token, server-side QR PNG, cashback compute, validate/commit, wallet aggregation), redemption router, thin offers PATCH stub, merchant analytics endpoint, and a CLI seed helper for accepted offers
- Frontend: wallet page with running cashback balance, redeem page with QR + paste-fallback token + 2-second polling that flips to a "Redeemed!" state when the merchant confirms, merchant scan page combining html5-qrcode camera with a paste-token textbox, and a merchant analytics dashboard
- Token-only QR encoding (not host URL) keeps the demo deploy-portable; paste fallback keeps the demo working without camera permissions

## Test plan

- [ ] Backend: ` cd backend && python seed.py ` then ` uvicorn main:app --port 8000 `
- [ ] Open ` http://localhost:3000/wallet ` in tab A; copy ` localStorage.getItem('city_wallet_session_id') ` from devtools
- [ ] ` cd backend && python seed_test_offers.py <session_id> ` to seed accepted offers with tokens
- [ ] Tab A: refresh ` /wallet `, verify offers under "Ready to use" and balance $0
- [ ] Tab A: click "Show QR" on an offer; verify QR + monospace token below
- [ ] Tab B: open ` /merchant/scan `; paste the token (or scan via camera); verify preview
- [ ] Tab B: click "Confirm Redemption"; verify success screen with cashback amount
- [ ] Tab A: verify the redeem page auto-flips to "Redeemed!" within ~2 seconds without manual refresh
- [ ] Tab A: refresh ` /wallet `; verify offer moved to Redeemed section and balance updated
- [ ] Tab B: visit ` /merchant `, select that merchant, verify analytics show ` total_redeemed: 1 `, correct rates, and revenue impact
- [ ] Re-validate the redeemed token returns ` valid: false ` (replay protection)