### PR TITLE
Module 1: Context Sensing Layer

### DIFF
--- a/backend/city_configs/nyc.json
+++ b/backend/city_configs/nyc.json
@@ -31,6 +31,11 @@
       "longitude": -73.9870,
       "address": "1 Rockefeller Plaza, New York, NY 10020",
       "image_url": null,
+      "brand_voice": "warm",
+      "signature_items": ["cappuccino", "single-origin pour-over", "almond croissant"],
+      "target_demographics": ["young_professional", "tourist", "office_worker"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 50.00,
       "rules": [
         {
           "max_discount_percent": 20,
@@ -60,6 +65,11 @@
       "longitude": -74.0021,
       "address": "7 Carmine St, New York, NY 10014",
       "image_url": null,
+      "brand_voice": "neighborly",
+      "signature_items": ["pepperoni slice", "margherita slice", "fresh mozzarella slice"],
+      "target_demographics": ["local", "student", "tourist"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 40.00,
       "rules": [
         {
           "max_discount_percent": 15,
@@ -89,6 +99,11 @@
       "longitude": -73.9909,
       "address": "828 Broadway, New York, NY 10003",
       "image_url": null,
+      "brand_voice": "sophisticated",
+      "signature_items": ["rare first editions", "Strand tote bag", "staff picks"],
+      "target_demographics": ["local", "tourist", "student"],
+      "primary_goal": "loyalty_reward",
+      "daily_budget_usd": 30.00,
       "rules": [
         {
           "max_discount_percent": 20,
@@ -118,6 +133,11 @@
       "longitude": -73.9804,
       "address": "167 W 74th St, New York, NY 10023",
       "image_url": null,
+      "brand_voice": "playful",
+      "signature_items": ["chocolate chip walnut cookie", "dark chocolate peanut butter cookie"],
+      "target_demographics": ["tourist", "family", "young_professional"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 35.00,
       "rules": [
         {
           "max_discount_percent": 15,
@@ -147,6 +167,11 @@
       "longitude": -73.9881,
       "address": "Madison Square Park, New York, NY 10010",
       "image_url": null,
+      "brand_voice": "playful",
+      "signature_items": ["ShackBurger", "crinkle-cut fries", "chocolate shake"],
+      "target_demographics": ["tourist", "office_worker", "family"],
+      "primary_goal": "event_capture",
+      "daily_budget_usd": 60.00,
       "rules": [
         {
           "max_discount_percent": 15,
@@ -176,6 +201,11 @@
       "longitude": -73.9959,
       "address": "52 Prince St, New York, NY 10012",
       "image_url": null,
+      "brand_voice": "sophisticated",
+      "signature_items": ["staff picks", "literary fiction", "espresso"],
+      "target_demographics": ["local", "young_professional", "tourist"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 25.00,
       "rules": [
         {
           "max_discount_percent": 20,
@@ -205,6 +235,11 @@
       "longitude": -73.9882,
       "address": "373 Broome St, New York, NY 10013",
       "image_url": null,
+      "brand_voice": "playful",
+      "signature_items": ["iced matcha latte", "pink drink", "matcha soft serve"],
+      "target_demographics": ["young_professional", "student", "tourist"],
+      "primary_goal": "loyalty_reward",
+      "daily_budget_usd": 40.00,
       "rules": [
         {
           "max_discount_percent": 15,
@@ -234,6 +269,11 @@
       "longitude": -73.9772,
       "address": "956 2nd Ave, New York, NY 10022",
       "image_url": null,
+      "brand_voice": "sophisticated",
+      "signature_items": ["truffle mac & cheese", "burger", "ricotta gnocchi"],
+      "target_demographics": ["young_professional", "couple", "tourist"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 45.00,
       "rules": [
         {
           "max_discount_percent": 20,
@@ -263,6 +303,11 @@
       "longitude": -73.9830,
       "address": "10 Columbus Cir, New York, NY 10019",
       "image_url": null,
+      "brand_voice": "friendly",
+      "signature_items": ["hot bar", "365 brand basics", "prepared salads"],
+      "target_demographics": ["local", "office_worker", "family"],
+      "primary_goal": "loyalty_reward",
+      "daily_budget_usd": 80.00,
       "rules": [
         {
           "max_discount_percent": 10,
@@ -292,6 +337,11 @@
       "longitude": -73.9712,
       "address": "897 Broadway, New York, NY 10003",
       "image_url": null,
+      "brand_voice": "sophisticated",
+      "signature_items": ["spin class", "personal training session", "recovery suite"],
+      "target_demographics": ["young_professional", "couple"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 30.00,
       "rules": [
         {
           "max_discount_percent": 20,
@@ -321,6 +371,11 @@
       "longitude": -73.9891,
       "address": "900 Broadway, New York, NY 10003",
       "image_url": null,
+      "brand_voice": "neighborly",
+      "signature_items": ["Flagship cheddar", "world's best mac & cheese", "cheese flight"],
+      "target_demographics": ["tourist", "office_worker", "couple"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 25.00,
       "rules": [
         {
           "max_discount_percent": 15,
@@ -350,6 +405,11 @@
       "longitude": -74.0023,
       "address": "30 W 8th St, New York, NY 10011",
       "image_url": null,
+      "brand_voice": "warm",
+      "signature_items": ["Hair Bender espresso", "cold brew", "Stumptown drip"],
+      "target_demographics": ["local", "young_professional", "student"],
+      "primary_goal": "fill_quiet_hours",
+      "daily_budget_usd": 45.00,
       "rules": [
         {
           "max_discount_percent": 20,

--- a/backend/city_configs/nyc.json
+++ b/backend/city_configs/nyc.json
@@ -11,8 +11,7 @@
   },
   "default_radius_meters": 1000,
   "weather": {
-    "openweathermap_city_id": 5128581,
-    "units": "imperial"
+    "openweathermap_city_id": 5128581
   },
   "context_tag_rules": {
     "cold_threshold_celsius": 10,

--- a/backend/database.py
+++ b/backend/database.py
@@ -13,6 +13,11 @@ CREATE TABLE IF NOT EXISTS merchants (
     longitude REAL NOT NULL,
     address TEXT,
     image_url TEXT,
+    brand_voice TEXT,
+    signature_items TEXT,
+    target_demographics TEXT,
+    primary_goal TEXT,
+    daily_budget_usd REAL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -73,10 +78,30 @@ async def get_db() -> aiosqlite.Connection:
     return db
 
 
+MERCHANT_PROFILE_COLUMNS = [
+    ("brand_voice", "TEXT"),
+    ("signature_items", "TEXT"),
+    ("target_demographics", "TEXT"),
+    ("primary_goal", "TEXT"),
+    ("daily_budget_usd", "REAL"),
+]
+
+
+async def _migrate_merchant_profile(db: aiosqlite.Connection) -> None:
+    """Idempotently add merchant onboarding columns to existing databases."""
+    cursor = await db.execute("PRAGMA table_info(merchants)")
+    rows = await cursor.fetchall()
+    existing = {r["name"] for r in rows}
+    for name, col_type in MERCHANT_PROFILE_COLUMNS:
+        if name not in existing:
+            await db.execute(f"ALTER TABLE merchants ADD COLUMN {name} {col_type}")
+
+
 async def init_db():
     db = await get_db()
     try:
         await db.executescript(SCHEMA)
+        await _migrate_merchant_profile(db)
         await db.commit()
     finally:
         await db.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from database import init_db
-from routers import merchants
+from routers import context, merchants
 
 
 @asynccontextmanager
@@ -23,6 +23,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(context.router)
 app.include_router(merchants.router)
 
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -41,10 +41,36 @@ class TransactionDensity(BaseModel):
     trend: str
 
 
+class MerchantLiveSignal(BaseModel):
+    """Continuously-polled merchant state (simulated). Distinct from density:
+    density is a single ratio for the current hour, this is the richer
+    operating state used by Claude to ground offer copy.
+    """
+    merchant_id: str
+    recent_txns_60min: list[int]                 # 6 ten-minute buckets, oldest first
+    inventory_flags: list[str] = []              # e.g. ["fresh_batch:cappuccino", "low_stock:croissants"]
+    staff_capacity: str = "normal"               # "low", "normal", "high"
+    daily_budget_burned_pct: float = 0.0         # 0.0-1.0, fraction of today's offer budget already spent
+    active_offer_count: int = 0
+
+
 class UserLocation(BaseModel):
     latitude: float
     longitude: float
     accuracy_meters: Optional[float] = None
+
+
+class CustomerIntent(BaseModel):
+    """Opaque, on-device-derived hints. Raw customer profile and live signals
+    never leave the device; an SLM summarizes them into this object before it
+    reaches the backend. All fields are optional — the engine works without them.
+    """
+    intent_tags: list[str] = []                  # e.g. ["warm_drink", "sit_down", "browsing"]
+    preferred_categories: list[str] = []         # e.g. ["cafe", "bakery"]
+    price_sensitivity: Optional[str] = None      # "low", "mid", "high"
+    movement_state: Optional[str] = None         # "stationary", "walking", "transit"
+    session_dwell_seconds: Optional[int] = None
+    declined_categories_today: list[str] = []
 
 
 class ContextState(BaseModel):
@@ -56,6 +82,7 @@ class ContextState(BaseModel):
     is_weekend: bool
     nearby_events: list[EventData]
     merchant_densities: list[TransactionDensity]
+    merchant_live_signals: list[MerchantLiveSignal] = []
     context_tags: list[str]
     urgency_score: float
 
@@ -96,6 +123,12 @@ class Merchant(BaseModel):
     longitude: float
     address: str
     image_url: Optional[str] = None
+    # Onboarding profile — captured during merchant signup, slow-changing
+    brand_voice: Optional[str] = None             # "friendly", "playful", "sophisticated", "neighborly"
+    signature_items: list[str] = []               # e.g. ["cappuccino", "single-origin pour-over"]
+    target_demographics: list[str] = []           # e.g. ["young_professional", "tourist"]
+    primary_goal: Optional[str] = None            # "fill_quiet_hours", "event_capture", "loyalty_reward"
+    daily_budget_usd: Optional[float] = None      # overall daily spend cap
     rules: list[MerchantRule] = []
 
 
@@ -176,7 +209,8 @@ class ContextRequest(BaseModel):
 class GenerateOffersRequest(BaseModel):
     context: ContextState
     max_offers: int = 3
-    user_preferences: Optional[dict] = None
+    customer_intent: Optional[CustomerIntent] = None  # opaque on-device summary; raw profile stays local
+    user_preferences: Optional[dict] = None  # legacy free-form hints, kept for compatibility
 
 
 class GenerateOffersResponse(BaseModel):

--- a/backend/routers/context.py
+++ b/backend/routers/context.py
@@ -1,0 +1,22 @@
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from models import ContextRequest, ContextState
+from services.context import compose_context
+
+
+router = APIRouter(prefix="/api/context", tags=["context"])
+
+
+@router.post("", response_model=ContextState)
+async def get_context(
+    request: ContextRequest,
+    demo: Optional[str] = Query(default=None),
+):
+    return await compose_context(
+        lat=request.latitude,
+        lng=request.longitude,
+        accuracy_meters=request.accuracy_meters,
+        demo_mode=demo,
+    )

--- a/backend/routers/context.py
+++ b/backend/routers/context.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 
 from models import ContextRequest, ContextState
 from services.context import compose_context
@@ -14,6 +14,8 @@ async def get_context(
     request: ContextRequest,
     demo: Optional[str] = Query(default=None),
 ):
+    if not (-90.0 <= request.latitude <= 90.0) or not (-180.0 <= request.longitude <= 180.0):
+        raise HTTPException(status_code=400, detail="latitude/longitude out of range")
     return await compose_context(
         lat=request.latitude,
         lng=request.longitude,

--- a/backend/routers/merchants.py
+++ b/backend/routers/merchants.py
@@ -49,6 +49,11 @@ async def list_merchants():
                     longitude=row["longitude"],
                     address=row["address"] or "",
                     image_url=row["image_url"],
+                    brand_voice=row["brand_voice"],
+                    signature_items=json.loads(row["signature_items"] or "[]"),
+                    target_demographics=json.loads(row["target_demographics"] or "[]"),
+                    primary_goal=row["primary_goal"],
+                    daily_budget_usd=row["daily_budget_usd"],
                     rules=rules,
                 )
             )

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -21,8 +21,10 @@ async def seed():
 
         for m in merchants:
             await db.execute(
-                """INSERT INTO merchants (id, name, category, description, latitude, longitude, address, image_url)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                """INSERT INTO merchants (
+                       id, name, category, description, latitude, longitude, address, image_url,
+                       brand_voice, signature_items, target_demographics, primary_goal, daily_budget_usd
+                   ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     m["id"],
                     m["name"],
@@ -32,6 +34,11 @@ async def seed():
                     m["longitude"],
                     m.get("address", ""),
                     m.get("image_url"),
+                    m.get("brand_voice"),
+                    json.dumps(m.get("signature_items", [])),
+                    json.dumps(m.get("target_demographics", [])),
+                    m.get("primary_goal"),
+                    m.get("daily_budget_usd"),
                 ),
             )
 

--- a/backend/services/context.py
+++ b/backend/services/context.py
@@ -1,0 +1,247 @@
+"""Context orchestrator.
+
+compose_context() is the single entry point used by the router. It runs
+the signal sources in parallel, derives semantic tags, and scores urgency.
+"""
+
+import asyncio
+import math
+from datetime import datetime, timedelta
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+from config import city_config
+from models import (
+    ContextState,
+    EventData,
+    TransactionDensity,
+    UserLocation,
+    WeatherCondition,
+    WeatherData,
+)
+from services import events as events_service
+from services import payone, weather as weather_service
+
+
+# --- time classification ---
+
+def classify_time(hour: int) -> str:
+    if 5 <= hour < 8:
+        return "early_morning"
+    if 8 <= hour < 11:
+        return "morning"
+    if 11 <= hour < 14:
+        return "lunch"
+    if 14 <= hour < 17:
+        return "afternoon"
+    if 17 <= hour < 21:
+        return "evening"
+    return "night"
+
+
+# --- haversine for distance filter ---
+
+def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    r = 6_371_000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+def _filter_nearby(merchants: list[dict], lat: float, lng: float, radius: float) -> list[dict]:
+    return [
+        m for m in merchants
+        if _haversine_meters(lat, lng, m["latitude"], m["longitude"]) <= radius
+    ]
+
+
+# --- tag derivation ---
+
+def derive_context_tags(
+    weather: WeatherData,
+    time_of_day: str,
+    is_weekend: bool,
+    events: list[EventData],
+    densities: list[TransactionDensity],
+    merchant_lookup: dict[str, dict],
+) -> list[str]:
+    rules = city_config["context_tag_rules"]
+    cold = rules["cold_threshold_celsius"]
+    hot = rules["hot_threshold_celsius"]
+    quiet_thr = rules["quiet_density_ratio"]
+    busy_thr = rules["busy_density_ratio"]
+
+    tags: list[str] = []
+
+    # weather
+    if weather.temp_celsius < cold:
+        tags.append("cold")
+    if weather.temp_celsius > hot:
+        tags.append("hot")
+    if weather.condition in (WeatherCondition.RAIN, WeatherCondition.STORM):
+        tags.append("rainy")
+    if weather.condition == WeatherCondition.SNOW:
+        tags.append("snowy")
+    if weather.condition == WeatherCondition.CLEAR:
+        tags.append("clear_sky")
+
+    # time
+    tags.append(time_of_day if time_of_day != "lunch" else "lunch_hour")
+    tags.append("weekend" if is_weekend else "weekday")
+
+    # events
+    if events:
+        tags.append("event_nearby")
+
+    # densities
+    if any(d.density_ratio < quiet_thr for d in densities):
+        tags.append("quiet_period")
+    if densities:
+        avg_ratio = sum(d.density_ratio for d in densities) / len(densities)
+        if avg_ratio > busy_thr:
+            tags.append("busy_area")
+
+    quiet_by_category: dict[str, bool] = {}
+    for d in densities:
+        if d.trend != "quiet":
+            continue
+        merchant = merchant_lookup.get(d.merchant_id)
+        if not merchant:
+            continue
+        quiet_by_category[merchant["category"]] = True
+
+    if quiet_by_category.get("cafe"):
+        tags.append("quiet_cafes")
+    if quiet_by_category.get("restaurant"):
+        tags.append("quiet_restaurants")
+
+    # de-dupe while preserving order
+    seen = set()
+    return [t for t in tags if not (t in seen or seen.add(t))]
+
+
+# --- urgency ---
+
+def compute_urgency(tags: list[str]) -> float:
+    score = 0.3  # baseline
+    if "rainy" in tags or "snowy" in tags:
+        score += 0.20
+    if "lunch_hour" in tags:
+        score += 0.15
+    if "quiet_period" in tags:
+        score += 0.15
+    if "event_nearby" in tags:
+        score += 0.10
+    if "cold" in tags:
+        score += 0.10
+    if "weekend" in tags and "afternoon" in tags:
+        score -= 0.10
+    if "clear_sky" in tags:
+        score -= 0.05
+    return max(0.0, min(1.0, round(score, 2)))
+
+
+# --- demo overrides ---
+
+DEMO_PRESETS = {
+    "rainy_afternoon": {
+        "weather": WeatherData(
+            condition=WeatherCondition.RAIN,
+            temp_celsius=11.0,
+            humidity=85,
+            description="light rain (demo)",
+        ),
+        "weekday": 1,   # Tuesday
+        "hour": 14,
+        "minute": 30,
+    },
+    "hot_weekend": {
+        "weather": WeatherData(
+            condition=WeatherCondition.CLEAR,
+            temp_celsius=32.0,
+            humidity=40,
+            description="sunny (demo)",
+        ),
+        "weekday": 5,   # Saturday
+        "hour": 12,
+        "minute": 0,
+    },
+    "event_night": {
+        "weather": WeatherData(
+            condition=WeatherCondition.CLOUDY,
+            temp_celsius=18.0,
+            humidity=65,
+            description="overcast (demo)",
+        ),
+        "weekday": 4,   # Friday
+        "hour": 19,
+        "minute": 0,
+    },
+}
+
+
+def _demo_now(preset: dict, tz: ZoneInfo) -> datetime:
+    """Anchor demo time on today, then shift to the preset's weekday."""
+    today = datetime.now(tz).replace(
+        hour=preset["hour"], minute=preset["minute"], second=0, microsecond=0
+    )
+    delta = (preset["weekday"] - today.weekday()) % 7
+    return today + timedelta(days=delta)
+
+
+# --- main orchestrator ---
+
+async def compose_context(
+    lat: float,
+    lng: float,
+    accuracy_meters: Optional[float] = None,
+    demo_mode: Optional[str] = None,
+) -> ContextState:
+    tz = ZoneInfo(city_config.get("timezone", "UTC"))
+    preset = DEMO_PRESETS.get(demo_mode) if demo_mode else None
+
+    if preset:
+        now = _demo_now(preset, tz)
+        weather = preset["weather"]
+        # Make the cached weather match so any subsequent caller sees demo state.
+        weather_service.override_cache(weather)
+        events_task = events_service.get_nearby_events(lat, lng, now=now)
+        events = await events_task
+    else:
+        now = datetime.now(tz)
+        weather, events = await asyncio.gather(
+            weather_service.get_weather(),
+            events_service.get_nearby_events(lat, lng, now=now),
+        )
+
+    time_of_day = classify_time(now.hour)
+    day_of_week = now.strftime("%A").lower()
+    is_weekend = day_of_week in ("saturday", "sunday")
+
+    radius = city_config.get("default_radius_meters", 1000)
+    nearby_merchants = _filter_nearby(payone.get_merchant_configs(), lat, lng, radius)
+    densities = payone.simulate_for_merchants(nearby_merchants, now.hour, weather, is_weekend)
+    live_signals = payone.simulate_live_signals_for(nearby_merchants, densities, now.hour)
+
+    merchant_lookup = {m["id"]: m for m in nearby_merchants}
+    tags = derive_context_tags(
+        weather, time_of_day, is_weekend, events, densities, merchant_lookup
+    )
+    urgency = compute_urgency(tags)
+
+    return ContextState(
+        timestamp=now,
+        location=UserLocation(latitude=lat, longitude=lng, accuracy_meters=accuracy_meters),
+        weather=weather,
+        time_of_day=time_of_day,
+        day_of_week=day_of_week,
+        is_weekend=is_weekend,
+        nearby_events=events,
+        merchant_densities=densities,
+        merchant_live_signals=live_signals,
+        context_tags=tags,
+        urgency_score=urgency,
+    )

--- a/backend/services/context.py
+++ b/backend/services/context.py
@@ -5,7 +5,6 @@ the signal sources in parallel, derives semantic tags, and scores urgency.
 """
 
 import asyncio
-import math
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 from zoneinfo import ZoneInfo
@@ -21,6 +20,7 @@ from models import (
 )
 from services import events as events_service
 from services import payone, weather as weather_service
+from services.geo import haversine_meters
 
 
 # --- time classification ---
@@ -39,22 +39,10 @@ def classify_time(hour: int) -> str:
     return "night"
 
 
-# --- haversine for distance filter ---
-
-def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
-    r = 6_371_000.0
-    p1 = math.radians(lat1)
-    p2 = math.radians(lat2)
-    dp = math.radians(lat2 - lat1)
-    dl = math.radians(lng2 - lng1)
-    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
-    return 2 * r * math.asin(math.sqrt(a))
-
-
 def _filter_nearby(merchants: list[dict], lat: float, lng: float, radius: float) -> list[dict]:
     return [
         m for m in merchants
-        if _haversine_meters(lat, lng, m["latitude"], m["longitude"]) <= radius
+        if haversine_meters(lat, lng, m["latitude"], m["longitude"]) <= radius
     ]
 
 
@@ -89,7 +77,7 @@ def derive_context_tags(
         tags.append("clear_sky")
 
     # time
-    tags.append(time_of_day if time_of_day != "lunch" else "lunch_hour")
+    tags.append(time_of_day)
     tags.append("weekend" if is_weekend else "weekday")
 
     # events
@@ -129,7 +117,7 @@ def compute_urgency(tags: list[str]) -> float:
     score = 0.3  # baseline
     if "rainy" in tags or "snowy" in tags:
         score += 0.20
-    if "lunch_hour" in tags:
+    if "lunch" in tags:
         score += 0.15
     if "quiet_period" in tags:
         score += 0.15
@@ -184,12 +172,16 @@ DEMO_PRESETS = {
 
 
 def _demo_now(preset: dict, tz: ZoneInfo) -> datetime:
-    """Anchor demo time on today, then shift to the preset's weekday."""
+    """Anchor demo time on the nearest matching weekday (forward or back),
+    so absolute-dated city events have a chance of falling inside the window.
+    """
     today = datetime.now(tz).replace(
         hour=preset["hour"], minute=preset["minute"], second=0, microsecond=0
     )
-    delta = (preset["weekday"] - today.weekday()) % 7
-    return today + timedelta(days=delta)
+    diff = (preset["weekday"] - today.weekday()) % 7
+    if diff > 3:
+        diff -= 7
+    return today + timedelta(days=diff)
 
 
 # --- main orchestrator ---
@@ -205,10 +197,11 @@ async def compose_context(
 
     if preset:
         local_now = _demo_now(preset, tz)
-        weather = preset["weather"]
-        # Make the cached weather match so any subsequent caller sees demo state.
-        weather_service.override_cache(weather)
-        events = await events_service.get_nearby_events(lat, lng, now=local_now)
+        # Per-request override: never poisons the shared cache for non-demo callers.
+        weather, events = await asyncio.gather(
+            weather_service.get_weather(override=preset["weather"]),
+            events_service.get_nearby_events(lat, lng, now=local_now),
+        )
     else:
         local_now = datetime.now(tz)
         weather, events = await asyncio.gather(
@@ -216,16 +209,17 @@ async def compose_context(
             events_service.get_nearby_events(lat, lng, now=local_now),
         )
 
-    # time-of-day and day-of-week are inherently local; the response timestamp is UTC
+    # time-of-day, day-of-week, and the hour passed to the merchant simulator
+    # are all inherently local; only the response timestamp is UTC.
     time_of_day = classify_time(local_now.hour)
     day_of_week = local_now.strftime("%A").lower()
     is_weekend = day_of_week in ("saturday", "sunday")
-    now = local_now.astimezone(timezone.utc)
+    now_utc = local_now.astimezone(timezone.utc)
 
     radius = city_config.get("default_radius_meters", 1000)
     nearby_merchants = _filter_nearby(payone.get_merchant_configs(), lat, lng, radius)
-    densities = payone.simulate_for_merchants(nearby_merchants, now.hour, weather, is_weekend)
-    live_signals = payone.simulate_live_signals_for(nearby_merchants, densities, now.hour)
+    densities = payone.simulate_for_merchants(nearby_merchants, local_now.hour, weather, is_weekend)
+    live_signals = payone.simulate_live_signals_for(nearby_merchants, densities, local_now.hour)
 
     merchant_lookup = {m["id"]: m for m in nearby_merchants}
     tags = derive_context_tags(
@@ -234,7 +228,7 @@ async def compose_context(
     urgency = compute_urgency(tags)
 
     return ContextState(
-        timestamp=now,
+        timestamp=now_utc,
         location=UserLocation(latitude=lat, longitude=lng, accuracy_meters=accuracy_meters),
         weather=weather,
         time_of_day=time_of_day,

--- a/backend/services/events.py
+++ b/backend/services/events.py
@@ -1,0 +1,76 @@
+"""Local event loader. Reads from the city config; swap for a live API
+(Eventbrite, NYC Open Data) without touching callers.
+"""
+
+import math
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from config import city_config
+from models import EventData
+
+
+def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    r = 6_371_000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+def _parse_dt(value) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(str(value))
+
+
+async def get_nearby_events(
+    lat: float,
+    lng: float,
+    now: datetime | None = None,
+) -> list[EventData]:
+    tz = ZoneInfo(city_config.get("timezone", "UTC"))
+    if now is None:
+        now = datetime.now(tz)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=tz)
+
+    radius = city_config["context_tag_rules"]["nearby_event_radius_meters"]
+
+    raw_events = city_config.get("events", [])
+    nearby: list[EventData] = []
+
+    for e in raw_events:
+        start = _parse_dt(e["start_time"])
+        end = _parse_dt(e["end_time"]) if e.get("end_time") else None
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=tz)
+        if end is not None and end.tzinfo is None:
+            end = end.replace(tzinfo=tz)
+
+        if start > now:
+            continue
+        if end is not None and end < now:
+            continue
+
+        distance = _haversine_meters(lat, lng, e["latitude"], e["longitude"])
+        if distance > radius:
+            continue
+
+        nearby.append(
+            EventData(
+                id=e["id"],
+                name=e["name"],
+                venue=e["venue"],
+                category=e["category"],
+                start_time=start,
+                end_time=end,
+                latitude=e["latitude"],
+                longitude=e["longitude"],
+                expected_attendance=e.get("expected_attendance"),
+            )
+        )
+
+    return nearby

--- a/backend/services/events.py
+++ b/backend/services/events.py
@@ -2,22 +2,12 @@
 (Eventbrite, NYC Open Data) without touching callers.
 """
 
-import math
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
 from config import city_config
 from models import EventData
-
-
-def _haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
-    r = 6_371_000.0
-    p1 = math.radians(lat1)
-    p2 = math.radians(lat2)
-    dp = math.radians(lat2 - lat1)
-    dl = math.radians(lng2 - lng1)
-    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
-    return 2 * r * math.asin(math.sqrt(a))
+from services.geo import haversine_meters
 
 
 def _parse_dt(value) -> datetime:
@@ -55,7 +45,7 @@ async def get_nearby_events(
         if end is not None and end < now:
             continue
 
-        distance = _haversine_meters(lat, lng, e["latitude"], e["longitude"])
+        distance = haversine_meters(lat, lng, e["latitude"], e["longitude"])
         if distance > radius:
             continue
 

--- a/backend/services/geo.py
+++ b/backend/services/geo.py
@@ -1,0 +1,13 @@
+"""Geo helpers shared by context and event services."""
+
+import math
+
+
+def haversine_meters(lat1: float, lng1: float, lat2: float, lng2: float) -> float:
+    r = 6_371_000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lng2 - lng1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))

--- a/backend/services/payone.py
+++ b/backend/services/payone.py
@@ -1,0 +1,155 @@
+"""Simulated Payone transaction density.
+
+Payone is a real DSV asset; we don't have API access, so we simulate
+realistic per-merchant traffic from patterns in the city config.
+Replace this module with a real client when access is available — the
+public surface is just `simulate_density` and `simulate_for_merchants`.
+"""
+
+import random
+
+from config import city_config
+from models import MerchantLiveSignal, TransactionDensity, WeatherCondition, WeatherData
+
+
+def _trend(density_ratio: float) -> str:
+    if density_ratio < 0.5:
+        return "quiet"
+    if density_ratio < 1.2:
+        return "normal"
+    if density_ratio < 1.8:
+        return "busy"
+    return "surging"
+
+
+def simulate_density(
+    merchant_config: dict,
+    current_hour: int,
+    weather: WeatherData,
+    is_weekend: bool,
+) -> TransactionDensity:
+    pattern = merchant_config.get("transaction_pattern", {})
+    base = float(pattern.get("avg_hourly_txns", 20))
+
+    if current_hour in pattern.get("peak_hours", []):
+        hour_mod = 1.5
+    elif current_hour in pattern.get("quiet_hours", []):
+        hour_mod = 0.4
+    else:
+        hour_mod = 1.0
+
+    rainy = weather.condition in (WeatherCondition.RAIN, WeatherCondition.STORM)
+    weather_mod = 0.7 if rainy else 1.0
+
+    weekend_mod = pattern.get("weekend_modifier", 1.0) if is_weekend else 1.0
+
+    noise = random.gauss(0, 0.15)
+
+    current_txns = int(base * hour_mod * weather_mod * weekend_mod * (1 + noise))
+    current_txns = max(0, current_txns)
+    density_ratio = current_txns / base if base > 0 else 1.0
+
+    return TransactionDensity(
+        merchant_id=merchant_config["id"],
+        current_hour_txns=current_txns,
+        avg_hour_txns=base,
+        density_ratio=round(density_ratio, 2),
+        trend=_trend(density_ratio),
+    )
+
+
+def simulate_for_merchants(
+    merchants: list[dict],
+    current_hour: int,
+    weather: WeatherData,
+    is_weekend: bool,
+) -> list[TransactionDensity]:
+    return [simulate_density(m, current_hour, weather, is_weekend) for m in merchants]
+
+
+def _staff_capacity(density_ratio: float) -> str:
+    if density_ratio < 0.6:
+        return "high"
+    if density_ratio > 1.4:
+        return "low"
+    return "normal"
+
+
+def _inventory_flags(merchant_config: dict, current_hour: int, density_ratio: float) -> list[str]:
+    """Heuristic inventory state from merchant config + current load.
+
+    Real Payone integration would replace this with live POS feed.
+    """
+    flags: list[str] = []
+    pattern = merchant_config.get("transaction_pattern", {})
+    signature = merchant_config.get("signature_items", [])
+    if not signature:
+        return flags
+
+    # Right after a quiet hour, surface a "fresh batch" hook on the first signature item
+    just_after_quiet = (current_hour - 1) in pattern.get("quiet_hours", [])
+    if just_after_quiet and density_ratio < 1.0:
+        flags.append(f"fresh_batch:{signature[0]}")
+
+    # During peak load, flag low stock on a second signature item
+    if density_ratio > 1.5 and len(signature) > 1:
+        flags.append(f"low_stock:{signature[1]}")
+
+    return flags
+
+
+def simulate_live_signal(
+    merchant_config: dict,
+    density: TransactionDensity,
+    current_hour: int,
+) -> MerchantLiveSignal:
+    """Construct a richer rolling-window view to sit alongside density.
+
+    Buckets the last 60 minutes into 6 ten-minute slices using the same
+    base rate the density used. Adds simulated inventory + staff state.
+    """
+    avg = max(1.0, density.avg_hour_txns)
+    per_bucket = (density.current_hour_txns or 0) / 6.0
+    buckets = []
+    for _ in range(6):
+        n = max(0, int(round(per_bucket * (1 + random.gauss(0, 0.25)))))
+        buckets.append(n)
+
+    rule_budgets = sum(
+        (r.get("budget_daily_usd") or 0.0)
+        for r in merchant_config.get("rules", [])
+    )
+    cap = merchant_config.get("daily_budget_usd") or rule_budgets or 50.0
+    burned = round(min(1.0, max(0.0, random.uniform(0.05, 0.65))), 2)
+    active_offers = max(0, int(round(density.density_ratio * 2)))
+
+    return MerchantLiveSignal(
+        merchant_id=merchant_config["id"],
+        recent_txns_60min=buckets,
+        inventory_flags=_inventory_flags(merchant_config, current_hour, density.density_ratio),
+        staff_capacity=_staff_capacity(density.density_ratio),
+        daily_budget_burned_pct=burned,
+        active_offer_count=active_offers,
+    )
+
+
+def simulate_live_signals_for(
+    merchants: list[dict],
+    densities: list[TransactionDensity],
+    current_hour: int,
+) -> list[MerchantLiveSignal]:
+    by_id = {m["id"]: m for m in merchants}
+    return [
+        simulate_live_signal(by_id[d.merchant_id], d, current_hour)
+        for d in densities
+        if d.merchant_id in by_id
+    ]
+
+
+def get_merchant_configs() -> list[dict]:
+    """Raw merchant entries from the city config (includes transaction_pattern).
+
+    Routers should still call the merchants table for the user-facing list;
+    this is for the simulator which needs the patterns.
+    """
+    return city_config.get("merchants", [])

--- a/backend/services/payone.py
+++ b/backend/services/payone.py
@@ -43,7 +43,12 @@ def simulate_density(
 
     weekend_mod = pattern.get("weekend_modifier", 1.0) if is_weekend else 1.0
 
-    noise = random.gauss(0, 0.15)
+    # Seeded RNG: same (merchant, hour, weather, weekend) -> same density across
+    # consecutive calls. Keeps consecutive /api/context responses stable.
+    rng = random.Random(
+        hash((merchant_config["id"], current_hour, weather.condition.value, is_weekend))
+    )
+    noise = rng.gauss(0, 0.15)
 
     current_txns = int(base * hour_mod * weather_mod * weekend_mod * (1 + noise))
     current_txns = max(0, current_txns)
@@ -108,19 +113,14 @@ def simulate_live_signal(
     Buckets the last 60 minutes into 6 ten-minute slices using the same
     base rate the density used. Adds simulated inventory + staff state.
     """
-    avg = max(1.0, density.avg_hour_txns)
+    rng = random.Random(hash((merchant_config["id"], current_hour)))
     per_bucket = (density.current_hour_txns or 0) / 6.0
-    buckets = []
-    for _ in range(6):
-        n = max(0, int(round(per_bucket * (1 + random.gauss(0, 0.25)))))
-        buckets.append(n)
+    buckets = [
+        max(0, int(round(per_bucket * (1 + rng.gauss(0, 0.25)))))
+        for _ in range(6)
+    ]
 
-    rule_budgets = sum(
-        (r.get("budget_daily_usd") or 0.0)
-        for r in merchant_config.get("rules", [])
-    )
-    cap = merchant_config.get("daily_budget_usd") or rule_budgets or 50.0
-    burned = round(min(1.0, max(0.0, random.uniform(0.05, 0.65))), 2)
+    burned = round(min(1.0, max(0.0, rng.uniform(0.05, 0.65))), 2)
     active_offers = max(0, int(round(density.density_ratio * 2)))
 
     return MerchantLiveSignal(

--- a/backend/services/weather.py
+++ b/backend/services/weather.py
@@ -1,0 +1,89 @@
+"""OpenWeatherMap client with 10-minute caching and graceful fallback.
+
+Swap this module to support a different provider (DWD, etc.) without
+touching the rest of the app — only the public functions matter.
+"""
+
+import time
+from typing import Optional
+
+import httpx
+
+from config import OPENWEATHERMAP_API_KEY, city_config
+from models import WeatherCondition, WeatherData
+
+
+CACHE_TTL_SECONDS = 600
+OWM_URL = "https://api.openweathermap.org/data/2.5/weather"
+
+_cache: dict = {"weather": None, "fetched_at": 0.0}
+
+
+def _map_condition(owm_id: int) -> WeatherCondition:
+    if 200 <= owm_id < 300:
+        return WeatherCondition.STORM
+    if 300 <= owm_id < 600:
+        return WeatherCondition.RAIN
+    if 600 <= owm_id < 700:
+        return WeatherCondition.SNOW
+    if owm_id == 800:
+        return WeatherCondition.CLEAR
+    return WeatherCondition.CLOUDY
+
+
+def _fallback() -> WeatherData:
+    return WeatherData(
+        condition=WeatherCondition.CLOUDY,
+        temp_celsius=15.0,
+        humidity=60,
+        description="cloudy (fallback)",
+    )
+
+
+async def get_weather(force_refresh: bool = False) -> WeatherData:
+    now = time.time()
+    if (
+        not force_refresh
+        and _cache["weather"] is not None
+        and now - _cache["fetched_at"] < CACHE_TTL_SECONDS
+    ):
+        return _cache["weather"]
+
+    if not OPENWEATHERMAP_API_KEY:
+        weather = _fallback()
+        _cache["weather"] = weather
+        _cache["fetched_at"] = now
+        return weather
+
+    city_id = city_config["weather"]["openweathermap_city_id"]
+    params = {"id": city_id, "appid": OPENWEATHERMAP_API_KEY, "units": "metric"}
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.get(OWM_URL, params=params)
+            resp.raise_for_status()
+            data = resp.json()
+
+        owm_id = data["weather"][0]["id"]
+        weather = WeatherData(
+            condition=_map_condition(owm_id),
+            temp_celsius=float(data["main"]["temp"]),
+            humidity=int(data["main"]["humidity"]),
+            description=data["weather"][0].get("description", ""),
+        )
+    except Exception:
+        weather = _fallback()
+
+    _cache["weather"] = weather
+    _cache["fetched_at"] = now
+    return weather
+
+
+def override_cache(weather: Optional[WeatherData]) -> None:
+    """For demo_mode: inject a preset reading without an API call."""
+    if weather is None:
+        _cache["weather"] = None
+        _cache["fetched_at"] = 0.0
+    else:
+        _cache["weather"] = weather
+        _cache["fetched_at"] = time.time()

--- a/backend/services/weather.py
+++ b/backend/services/weather.py
@@ -40,7 +40,16 @@ def _fallback() -> WeatherData:
     )
 
 
-async def get_weather(force_refresh: bool = False) -> WeatherData:
+async def get_weather(
+    force_refresh: bool = False,
+    override: Optional[WeatherData] = None,
+) -> WeatherData:
+    # Per-request override (used by demo mode). Returns immediately and never
+    # touches the shared cache, so a demo call cannot poison subsequent
+    # non-demo callers for up to 10 minutes.
+    if override is not None:
+        return override
+
     now = time.time()
     if (
         not force_refresh
@@ -79,11 +88,3 @@ async def get_weather(force_refresh: bool = False) -> WeatherData:
     return weather
 
 
-def override_cache(weather: Optional[WeatherData]) -> None:
-    """For demo_mode: inject a preset reading without an API call."""
-    if weather is None:
-        _cache["weather"] = None
-        _cache["fetched_at"] = 0.0
-    else:
-        _cache["weather"] = weather
-        _cache["fetched_at"] = time.time()

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -29,6 +29,24 @@ export interface TransactionDensity {
   trend: "quiet" | "normal" | "busy" | "surging";
 }
 
+export interface MerchantLiveSignal {
+  merchant_id: string;
+  recent_txns_60min: number[];
+  inventory_flags: string[];
+  staff_capacity: "low" | "normal" | "high";
+  daily_budget_burned_pct: number;
+  active_offer_count: number;
+}
+
+export interface CustomerIntent {
+  intent_tags: string[];
+  preferred_categories: string[];
+  price_sensitivity?: "low" | "mid" | "high" | null;
+  movement_state?: "stationary" | "walking" | "transit" | null;
+  session_dwell_seconds?: number | null;
+  declined_categories_today: string[];
+}
+
 export interface UserLocation {
   latitude: number;
   longitude: number;
@@ -44,6 +62,7 @@ export interface ContextState {
   is_weekend: boolean;
   nearby_events: EventData[];
   merchant_densities: TransactionDensity[];
+  merchant_live_signals: MerchantLiveSignal[];
   context_tags: string[];
   urgency_score: number;
 }
@@ -83,6 +102,11 @@ export interface Merchant {
   longitude: number;
   address: string;
   image_url: string | null;
+  brand_voice: string | null;
+  signature_items: string[];
+  target_demographics: string[];
+  primary_goal: string | null;
+  daily_budget_usd: number | null;
   rules: MerchantRule[];
 }
 
@@ -157,6 +181,7 @@ export interface ContextRequest {
 export interface GenerateOffersRequest {
   context: ContextState;
   max_offers?: number;
+  customer_intent?: CustomerIntent;
   user_preferences?: {
     intent_tags?: string[];
     past_categories?: string[];


### PR DESCRIPTION
## Summary
- Adds the Context Sensing Layer backend (Module 1): weather, events, simulated Payone density + richer live signals, and a context orchestrator that derives semantic tags and an urgency score.
- New endpoint: `POST /api/context` (with `?demo=rainy_afternoon|hot_weekend|event_night` overrides for live demo).
- Hybrid privacy model in line with `docs/privacy-gdpr.md`: customer onboarding + live signals stay client-side and reach the backend only as an opaque `CustomerIntent`. Merchant onboarding (`brand_voice`, `signature_items`, `target_demographics`, `primary_goal`, `daily_budget_usd`) is server-side; merchant live signals are simulated per-request alongside density.
- Schema migration is non-destructive: `init_db()` runs idempotent `ALTER TABLE merchants ADD COLUMN ...` so existing dev DBs upgrade in place. `seed.py` and `routers/merchants.py` read/write the new fields.

## Compatibility with main (Module 3)
- Merged `origin/main`. Single conflict in `backend/main.py` (router import line); `routers/merchants.py` auto-merged so the new analytics endpoint and the new merchant onboarding fields coexist.
- Adopted the new "all timestamps UTC" convention: `ContextState.timestamp` is now `datetime.now(timezone.utc)`. Local time is still used for `time_of_day` / `day_of_week` classification (which is inherently location-bound).

## Test plan
- [x] `POST /api/context` returns full ContextState with tags, urgency, merchant_densities, merchant_live_signals
- [x] `?demo=rainy_afternoon|hot_weekend|event_night` overrides weather + time
- [x] OpenWeatherMap key activates fallback gracefully when missing or invalid
- [x] `GET /api/merchants` returns 12 merchants with onboarding profile fields populated after `python seed.py`
- [x] `GET /api/merchants/{id}/analytics` (Module 3 endpoint) still returns 200
- [x] Backend reloads cleanly after merge
- [ ] Frontend mirror types in `lib/types.ts` (deferred to Module 2 wire-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)