### PR TITLE
Refine onboarding: copy, privacy, step persistence

### DIFF
--- a/frontend/src/app/privacy/page.tsx
+++ b/frontend/src/app/privacy/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import type { CSSProperties } from "react";
-import Link from "next/link";
-import { clearConsent } from "@/components/ConsentModal";
+import { clearConsent, getConsent } from "@/components/ConsentModal";
 import { useRouter } from "next/navigation";
 
 const page: CSSProperties = {
@@ -119,6 +118,7 @@ const dangerBtn: CSSProperties = {
 
 export default function PrivacyPage() {
   const router = useRouter();
+  const isOnboarded = getConsent() !== null;
 
   const handleClearData = () => {
     clearConsent();
@@ -127,13 +127,16 @@ export default function PrivacyPage() {
 
   return (
     <div style={page}>
-      <Link
-        href="/"
+      <button
+        onClick={() => router.back()}
         style={{
           fontFamily: "var(--font-body)",
           fontSize: "var(--fs-small)",
           color: "var(--fg-link)",
-          textDecoration: "none",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          padding: 0,
           display: "inline-flex",
           alignItems: "center",
           gap: "4px",
@@ -142,7 +145,7 @@ export default function PrivacyPage() {
       >
         <i className="ph ph-arrow-left" style={{ fontSize: "14px" }} />
         Back
-      </Link>
+      </button>
 
       <h1 style={heading}>How your data is handled</h1>
       <p style={body}>
@@ -274,15 +277,18 @@ export default function PrivacyPage() {
         ))}
       </div>
 
-      {/* Clear data */}
-      <h2 style={sectionTitle}>Clear my data</h2>
-      <p style={{ ...body, marginBottom: "16px" }}>
-        This removes your consent, session, and all locally stored data. The app will show the welcome screen again.
-      </p>
+      {isOnboarded && (
+        <>
+          <h2 style={sectionTitle}>Clear my data</h2>
+          <p style={{ ...body, marginBottom: "16px" }}>
+            This removes your consent, preferences, and all locally stored data. The app will show the welcome screen again.
+          </p>
 
-      <button onClick={handleClearData} style={dangerBtn}>
-        Clear all data and revoke consent
-      </button>
+          <button onClick={handleClearData} style={dangerBtn}>
+            Clear all data and revoke consent
+          </button>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/ConsentModal.tsx
+++ b/frontend/src/components/ConsentModal.tsx
@@ -186,11 +186,11 @@ function WelcomeScreen({ onNext }: { onNext: () => void }) {
       </div>
 
       <h1 style={hero}>
-        The right offer, right when you need it.
+        Shop local. Save local.
       </h1>
 
       <p style={subtitle}>
-        City Wallet finds what is nearby, open, and worth your time.
+        Discover real-time offers from small businesses near you.
       </p>
 
       <button onClick={onNext} style={primaryBtn}>
@@ -544,11 +544,29 @@ function LocationScreen({ onConsent }: ConsentModalProps) {
 
 // -- Main component: 4-step flow --
 
+const STEP_KEY = "city_wallet_onboarding_step";
+
+function readStep(): 1 | 2 | 3 | 4 {
+  if (typeof window === "undefined") return 1;
+  const n = Number(sessionStorage.getItem(STEP_KEY));
+  return n >= 1 && n <= 4 ? (n as 1 | 2 | 3 | 4) : 1;
+}
+
 export default function ConsentModal({ onConsent }: ConsentModalProps) {
-  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
+  const [step, setStepState] = useState<1 | 2 | 3 | 4>(readStep);
+
+  const setStep = (s: 1 | 2 | 3 | 4) => {
+    sessionStorage.setItem(STEP_KEY, String(s));
+    setStepState(s);
+  };
+
+  const handleConsent = (locationEnabled: boolean) => {
+    sessionStorage.removeItem(STEP_KEY);
+    onConsent(locationEnabled);
+  };
 
   if (step === 1) return <WelcomeScreen onNext={() => setStep(2)} />;
   if (step === 2) return <ProfileScreen onNext={() => setStep(3)} />;
   if (step === 3) return <TasteScreen onNext={() => setStep(4)} onSkip={() => setStep(4)} />;
-  return <LocationScreen onConsent={onConsent} />;
+  return <LocationScreen onConsent={handleConsent} />;
 }


### PR DESCRIPTION
## Summary
- Welcome screen copy changed to "Shop local. Save local." with small-business focus
- Privacy page hides "Clear my data" section during onboarding, shows it only after user completes onboarding
- Privacy back button uses `router.back()` so it returns to location consent screen (not welcome)
- Onboarding step persisted in `sessionStorage` — navigating to `/privacy` and back preserves position
- Added `.claude/` to `.gitignore`

## Test plan
- [ ] Clear localStorage/sessionStorage, walk through onboarding — verify new welcome copy
- [ ] On location consent screen, tap "How your data is handled" → verify no "Clear my data" section
- [ ] Tap Back on privacy page → verify it returns to location consent, not welcome screen
- [ ] Complete onboarding, visit `/privacy` → verify "Clear my data" section appears
- [ ] Clear data → verify it returns to onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)