### PR TITLE
fix: expire stale accepted offers when listing wallet

### DIFF
--- a/backend/routers/offers.py
+++ b/backend/routers/offers.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from datetime import datetime, timezone
 
 import anthropic
 from fastapi import APIRouter, HTTPException, Query
@@ -43,6 +44,14 @@ async def list_offers(
 ):
     db = await get_db()
     try:
+        now_iso = datetime.now(timezone.utc).isoformat()
+        await db.execute(
+            "UPDATE offers SET status = ? "
+            "WHERE user_session_id = ? AND status = ? AND expires_at IS NOT NULL AND expires_at <= ?",
+            (OfferStatus.EXPIRED.value, session_id, OfferStatus.ACCEPTED.value, now_iso),
+        )
+        await db.commit()
+
         if status is not None:
             cursor = await db.execute(
                 "SELECT * FROM offers WHERE user_session_id = ? AND status = ? ORDER BY created_at DESC",


### PR DESCRIPTION
## Summary
- Expire stale accepted offers when listing the wallet so users don't see offers past their expiration

## Test plan
- [ ] Accept an offer, wait until expiration, load wallet, verify it's marked expired
- [ ] Verify non-expired accepted offers still appear normally